### PR TITLE
fix: remove invalid stdout JSON from PreToolUse hooks

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,6 +21,15 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-check-tasks\""
           }
         ]
+      },
+      {
+        "matcher": "TaskUpdate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/pre-task-complete-check-verification\""
+          }
+        ]
       }
     ]
   }

--- a/hooks/pre-commit-check-tasks
+++ b/hooks/pre-commit-check-tasks
@@ -3,18 +3,18 @@
 # Only triggers on Bash tool calls containing "git commit".
 
 # No set -e: if anything fails unexpectedly, fall through to allow.
-trap 'echo "{\"decision\": \"allow\"}"; exit 0' ERR
+trap 'exit 0' ERR
 
 INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-[[ "$TOOL_NAME" != "Bash" ]] && echo '{"decision": "allow"}' && exit 0
+[[ "$TOOL_NAME" != "Bash" ]] && exit 0
 
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-echo "$COMMAND" | grep -q 'git commit' || { echo '{"decision": "allow"}'; exit 0; }
+echo "$COMMAND" | grep -q 'git commit' || exit 0
 
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
-[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && echo '{"decision": "allow"}' && exit 0
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
 
 OPEN_TASKS=$(python3 -c "
 import json
@@ -46,5 +46,4 @@ if [[ "$OPEN_TASKS" -gt 0 ]]; then
     exit 2
 fi
 
-echo '{"decision": "allow"}'
 exit 0

--- a/hooks/pre-task-complete-check-verification
+++ b/hooks/pre-task-complete-check-verification
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block TaskUpdate(completed) when task requires user verification
+# but no AskUserQuestion was called for it.
+
+# Fail-safe: if anything breaks, allow (don't block on hook errors)
+trap 'echo "{\"decision\": \"allow\"}"; exit 0' ERR
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+[[ "$TOOL_NAME" != "TaskUpdate" ]] && echo '{"decision": "allow"}' && exit 0
+
+STATUS=$(echo "$INPUT" | jq -r '.tool_input.status // empty')
+[[ "$STATUS" != "completed" ]] && echo '{"decision": "allow"}' && exit 0
+
+TASK_ID=$(echo "$INPUT" | jq -r '.tool_input.taskId // empty')
+[[ -z "$TASK_ID" ]] && echo '{"decision": "allow"}' && exit 0
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && echo '{"decision": "allow"}' && exit 0
+
+# Check if this task requires user verification by scanning transcript for its TaskCreate
+REQUIRES_VERIFICATION=$(python3 -c "
+import json, sys
+task_id = '$TASK_ID'
+found_create = False
+description = ''
+create_count = 0
+for line in open('$TRANSCRIPT_PATH'):
+    try: entry = json.loads(line)
+    except: continue
+    if entry.get('type') != 'assistant': continue
+    for c in entry.get('message', {}).get('content', []):
+        if c.get('type') != 'tool_use': continue
+        name, inp = c.get('name', ''), c.get('input', {})
+        if name == 'TaskCreate':
+            create_count += 1
+            if str(create_count) == task_id:
+                description = inp.get('description', '')
+                found_create = True
+                break
+    if found_create: break
+
+if not found_create:
+    print('no')
+    sys.exit(0)
+
+if '\"requiresUserVerification\": true' in description or '\"requiresUserVerification\":true' in description:
+    print('yes')
+else:
+    print('no')
+" 2>/dev/null || echo "no")
+
+[[ "$REQUIRES_VERIFICATION" != "yes" ]] && echo '{"decision": "allow"}' && exit 0
+
+# Task requires verification — check if AskUserQuestion was called after task was in_progress
+HAS_ASK=$(python3 -c "
+import json
+task_id = '$TASK_ID'
+task_in_progress = False
+found_ask = False
+for line in open('$TRANSCRIPT_PATH'):
+    try: entry = json.loads(line)
+    except: continue
+    if entry.get('type') != 'assistant': continue
+    for c in entry.get('message', {}).get('content', []):
+        if c.get('type') != 'tool_use': continue
+        name, inp = c.get('name', ''), c.get('input', {})
+        if name == 'TaskUpdate' and str(inp.get('taskId', '')) == task_id and inp.get('status') == 'in_progress':
+            task_in_progress = True
+        if task_in_progress and name == 'AskUserQuestion':
+            found_ask = True
+            break
+    if found_ask: break
+print('yes' if found_ask else 'no')
+" 2>/dev/null || echo "yes")
+
+if [[ "$HAS_ASK" != "yes" ]]; then
+    echo "TASK COMPLETION BLOCKED: Task #$TASK_ID has requiresUserVerification=true but no AskUserQuestion was called. You MUST call AskUserQuestion with the verification prompt before marking this task complete." >&2
+    exit 2
+fi
+
+echo '{"decision": "allow"}'
+exit 0

--- a/hooks/pre-task-complete-check-verification
+++ b/hooks/pre-task-complete-check-verification
@@ -3,21 +3,21 @@
 # but no AskUserQuestion was called for it.
 
 # Fail-safe: if anything breaks, allow (don't block on hook errors)
-trap 'echo "{\"decision\": \"allow\"}"; exit 0' ERR
+trap 'exit 0' ERR
 
 INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-[[ "$TOOL_NAME" != "TaskUpdate" ]] && echo '{"decision": "allow"}' && exit 0
+[[ "$TOOL_NAME" != "TaskUpdate" ]] && exit 0
 
 STATUS=$(echo "$INPUT" | jq -r '.tool_input.status // empty')
-[[ "$STATUS" != "completed" ]] && echo '{"decision": "allow"}' && exit 0
+[[ "$STATUS" != "completed" ]] && exit 0
 
 TASK_ID=$(echo "$INPUT" | jq -r '.tool_input.taskId // empty')
-[[ -z "$TASK_ID" ]] && echo '{"decision": "allow"}' && exit 0
+[[ -z "$TASK_ID" ]] && exit 0
 
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
-[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && echo '{"decision": "allow"}' && exit 0
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
 
 # Check if this task requires user verification by scanning transcript for its TaskCreate
 REQUIRES_VERIFICATION=$(python3 -c "
@@ -51,7 +51,7 @@ else:
     print('no')
 " 2>/dev/null || echo "no")
 
-[[ "$REQUIRES_VERIFICATION" != "yes" ]] && echo '{"decision": "allow"}' && exit 0
+[[ "$REQUIRES_VERIFICATION" != "yes" ]] && exit 0
 
 # Task requires verification — check if AskUserQuestion was called after task was in_progress
 HAS_ASK=$(python3 -c "
@@ -80,5 +80,4 @@ if [[ "$HAS_ASK" != "yes" ]]; then
     exit 2
 fi
 
-echo '{"decision": "allow"}'
 exit 0

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -67,8 +67,12 @@ For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. **Use metadata for verification:** Parse the `json:metadata` code fence from the task description. Run `verifyCommand` and check each `acceptanceCriteria` before marking complete.
-4. Mark as completed
-5. **Sync `.tasks.json`:** Read the tasks file, update the task's `"status"` to `"completed"` (or `"in_progress"` in step 1), set `"lastUpdated"` to current ISO timestamp, write back. This keeps the persistence file in sync with native tasks for cross-session resume.
+4. **User verification gate:** If `requiresUserVerification` is `true` in the task's `json:metadata`:
+   - You MUST call `AskUserQuestion` using the `userVerificationPrompt` from the metadata (or the verification block in the task description)
+   - If the user selects the negative/rework option: go back to step 2, fix the issues, re-verify, then ask again
+   - **This is NOT optional.** Skipping user verification when the metadata requires it is a plan violation.
+5. Mark as completed
+6. **Sync `.tasks.json`:** Read the tasks file, update the task's `"status"` to `"completed"` (or `"in_progress"` in step 1), set `"lastUpdated"` to current ISO timestamp, write back. This keeps the persistence file in sync with native tasks for cross-session resume.
 
 ### Step 3: Complete Development
 
@@ -99,6 +103,7 @@ After all tasks complete and verified:
 - Review plan critically first
 - Follow plan steps exactly
 - Don't skip verifications
+- Never skip user verification when task metadata requires it — call AskUserQuestion
 - Reference skills when plan says to
 - Stop when blocked, don't guess
 - Never start implementation on main/master branch without explicit user consent

--- a/skills/shared/task-format-reference.md
+++ b/skills/shared/task-format-reference.md
@@ -37,8 +37,8 @@ Embed metadata as a `json:metadata` code fence at the end of the TaskCreate desc
 | `verifyCommand` | string | yes | Command to verify task completion |
 | `acceptanceCriteria` | string[] | yes | List of testable criteria |
 | `estimatedScope` | "small" \| "medium" \| "large" | no | Relative effort indicator |
-| `requiresUserVerification` | boolean | no | Task completion requires explicit user approval via AskUserQuestion. Set by writing-plans when prompt contains verification keywords. |
-| `userVerificationPrompt` | string | no | The specific question to ask the user for verification. Used by execution skills to construct the AskUserQuestion call. |
+| `requiresUserVerification` | boolean | **yes** | Whether task completion requires explicit user approval via AskUserQuestion. Always present — explicitly `true` or `false`. Forces active decision per task. |
+| `userVerificationPrompt` | string | conditional | The specific question to ask the user. **Required when `requiresUserVerification` is `true`.** Used by execution skills to construct the AskUserQuestion call. |
 
 ### Example
 

--- a/skills/shared/task-format-reference.md
+++ b/skills/shared/task-format-reference.md
@@ -37,6 +37,8 @@ Embed metadata as a `json:metadata` code fence at the end of the TaskCreate desc
 | `verifyCommand` | string | yes | Command to verify task completion |
 | `acceptanceCriteria` | string[] | yes | List of testable criteria |
 | `estimatedScope` | "small" \| "medium" \| "large" | no | Relative effort indicator |
+| `requiresUserVerification` | boolean | no | Task completion requires explicit user approval via AskUserQuestion. Set by writing-plans when prompt contains verification keywords. |
+| `userVerificationPrompt` | string | no | The specific question to ask the user for verification. Used by execution skills to construct the AskUserQuestion call. |
 
 ### Example
 
@@ -58,6 +60,39 @@ TaskCreate:
 
     ```json:metadata
     {"files": [".claude/commands/hame-optimal-cycle-inspection.md"], "verifyCommand": "grep -A 20 'Step 2' .claude/commands/hame-optimal-cycle-inspection.md", "acceptanceCriteria": ["AskUserQuestion with 3 JIT options", "SOC + schedule parsed from selection", "--jit override bypasses prompt"]}
+    ```
+```
+
+### Verification Task Example
+
+When a plan prompt contains user verification requirements (e.g., "verify with user", "confirm with user", "get user approval"), the task metadata encodes this so execution skills know to gate completion on explicit user approval.
+
+```yaml
+TaskCreate:
+  subject: "Verify hook error reduction with user"
+  description: |
+    **Goal:** Get user confirmation that hook errors have been reduced after applying fixes.
+
+    **Acceptance Criteria:**
+    - [ ] Hook error count has been measured post-fix
+    - [ ] User has explicitly confirmed the reduction
+    - [ ] Verification result is recorded in task update
+
+    **User Verification Required:**
+    Before marking this task complete, you MUST call AskUserQuestion:
+    ```yaml
+    AskUserQuestion:
+      question: "Hook error count was 38 before the fix. How many hook errors do you see now?"
+      header: "Verification"
+      options:
+        - label: "Reduced (fewer than 38)"
+          description: "Error count has improved — verification passed"
+        - label: "Same or worse"
+          description: "No improvement observed — needs rework"
+    ```
+
+    ```json:metadata
+    {"files": [], "verifyCommand": "echo 'Requires user verification'", "acceptanceCriteria": ["User confirms hook error reduction", "Verification result recorded"], "requiresUserVerification": true, "userVerificationPrompt": "Hook error count was 38 before the fix. How many hook errors do you see now?"}
     ```
 ```
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -55,6 +55,8 @@ digraph process {
         "Dispatch code quality reviewer subagent (skills/subagent-driven-development/code-quality-reviewer-prompt.md)" [shape=box];
         "Code quality reviewer subagent approves?" [shape=diamond];
         "Implementer subagent fixes quality issues" [shape=box];
+        "Task requires user verification? (check json:metadata)" [shape=diamond];
+        "AskUserQuestion: user verification prompt" [shape=box];
         "TaskUpdate: mark task completed" [shape=box];
     }
 
@@ -76,7 +78,11 @@ digraph process {
     "Dispatch code quality reviewer subagent (skills/subagent-driven-development/code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
     "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
     "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (skills/subagent-driven-development/code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "TaskUpdate: mark task completed" [label="yes"];
+    "Code quality reviewer subagent approves?" -> "Task requires user verification? (check json:metadata)" [label="yes"];
+        "Task requires user verification? (check json:metadata)" -> "AskUserQuestion: user verification prompt" [label="yes"];
+        "Task requires user verification? (check json:metadata)" -> "TaskUpdate: mark task completed" [label="no"];
+        "AskUserQuestion: user verification prompt" -> "TaskUpdate: mark task completed" [label="approved"];
+        "AskUserQuestion: user verification prompt" -> "Implementer subagent fixes quality issues" [label="changes needed"];
     "TaskUpdate: mark task completed" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (skills/subagent-driven-development/implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
@@ -90,6 +96,16 @@ When dispatching an implementer subagent:
 1. Read the task's description via TaskGet — metadata is embedded as a `json:metadata` code fence at the end
 2. Parse the metadata JSON and map fields (files, acceptanceCriteria, verifyCommand) to the implementer prompt sections
 3. The implementer should receive ALL structured data — don't make them parse it from prose
+
+## User Verification Gate
+
+After both reviews pass, check the task's `json:metadata` for `"requiresUserVerification": true`.
+
+**If set:** The controller (you) MUST call `AskUserQuestion` using the `userVerificationPrompt` from the metadata before marking the task complete. This is a human-in-the-loop gate — no subagent can satisfy it.
+
+**If the user selects the negative option:** Dispatch the implementer to fix the reported issues, then re-run both reviews, then ask the user again.
+
+**This is the controller's responsibility, not the implementer's or reviewer's.** Subagents cannot call AskUserQuestion — only the controller can. The `requiresUserVerification` flag exists precisely to guarantee human sign-off on critical tasks.
 
 ## Model Selection
 
@@ -252,6 +268,8 @@ Done!
 - Skip review loops (reviewer found issues = implementer fixes = review again)
 - Let implementer self-review replace actual review (both are needed)
 - **Start code quality review before spec compliance is ✅** (wrong order)
+- **Skip user verification when task metadata has `requiresUserVerification: true`** (the user explicitly requested this gate)
+- Let a subagent handle user verification (only the controller can call AskUserQuestion)
 - Move to next task while either review has open issues
 
 **If subagent asks questions:**

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -79,8 +79,17 @@ Key principle: TDD cycles happen WITHIN tasks, not as separate tasks. A task is 
 
 **Tech Stack:** [Key technologies/libraries]
 
+**User Verification:** [YES — what the user wants verified, by whom, and when] or [NO — no user verification required]
+
 ---
 ```
+
+**The User Verification field is mandatory.** Re-read the original prompt/spec and answer: does it require any form of user feedback, user confirmation, human sign-off, or human-in-the-loop validation? This is about intent, not exact keywords. Examples:
+- "verify with the user after each module" → YES — user confirms each module's output before proceeding
+- "terugkoppeling van users hoeveel foutmeldingen die ziet" → YES — user reports observed error count
+- "add a caching layer" → NO
+
+If YES: every task that requires user verification MUST include the standard verification block (see User Verification Enforcement section below). If you write YES here but create no verification tasks, the HARD-GATE before Execution Handoff will catch the gap.
 
 ## Task Structure
 
@@ -311,10 +320,12 @@ TaskCreate:
     [Key actions from task's Steps — abbreviated]
 
     ```json:metadata
-    {"files": ["path/to/file1.py"], "verifyCommand": "pytest tests/path/ -v", "acceptanceCriteria": ["criterion 1", "criterion 2"]}
+    {"files": ["path/to/file1.py"], "verifyCommand": "pytest tests/path/ -v", "acceptanceCriteria": ["criterion 1", "criterion 2"], "requiresUserVerification": false}
     ```
   activeForm: "Implementing [Component Name]"
 ```
+
+**`requiresUserVerification` is a required field in every task's metadata** — always present, explicitly `true` or `false`. When `true`, also include `userVerificationPrompt` and the standard verification block in the description (see User Verification Enforcement section). This forces an active decision per task rather than allowing verification to be silently omitted.
 
 ### Why Embedded Metadata
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -161,7 +161,71 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
 
+**4. Verification requirement scan:** Re-read the original prompt/spec. Did it request user verification, user feedback, user approval, or any form of human-in-the-loop confirmation? If yes: verify that at least one task has `requiresUserVerification: true` in its metadata and includes the standard verification block. If no such task exists, add one.
+
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+
+## User Verification Detection
+
+After writing the plan tasks but BEFORE creating native tasks, scan the original prompt/spec for user verification requirements.
+
+**Detection keywords** (match any of these in the prompt, spec, or task descriptions):
+- "user verification", "user approval", "user confirmation", "user feedback"
+- "ask the user", "confirm with user", "check with user", "verify with user"
+- "human review", "human approval", "manual verification"
+- "requires approval", "needs confirmation", "must confirm"
+- "feedback from users", "user reports", "user observes"
+
+**When verification keywords are detected:**
+
+1. Create dedicated verification task(s) — or add verification to existing tasks if the verification is part of that task's scope
+2. Set `"requiresUserVerification": true` in the task's `json:metadata`
+3. Set `"userVerificationPrompt"` to the specific question for the user
+4. Include the **standard verification block** in the task description (copy verbatim):
+
+**Standard verification block format:**
+
+~~~markdown
+**User Verification Required:**
+Before marking this task complete, you MUST call AskUserQuestion:
+```yaml
+AskUserQuestion:
+  question: "[specific question derived from the prompt's verification requirement]"
+  header: "Verification"
+  options:
+    - label: "[positive outcome]"
+      description: "[what this means]"
+    - label: "[negative outcome / needs rework]"
+      description: "[what happens next]"
+```
+~~~
+
+**If the user selects the negative option:** The task is NOT complete. Rework, then re-verify with AskUserQuestion again.
+
+**Example — prompt says "plan must include user feedback on error count":**
+
+The plan should include a task like:
+
+> **Task N: Verify error reduction with user**
+>
+> **Goal:** Get user confirmation that hook errors have decreased from baseline.
+>
+> **User Verification Required:**
+> Before marking this task complete, you MUST call AskUserQuestion:
+> ```yaml
+> AskUserQuestion:
+>   question: "How many hook errors do you see per Bash command? (baseline: 38)"
+>   header: "Verification"
+>   options:
+>     - label: "Reduced"
+>       description: "Fewer than 38 errors — improvement confirmed"
+>     - label: "Same or worse"
+>       description: "No improvement — needs rework"
+> ```
+>
+> ```json:metadata
+> {"files": [], "verifyCommand": "", "acceptanceCriteria": ["user confirms error reduction"], "requiresUserVerification": true, "userVerificationPrompt": "How many hook errors do you see per Bash command? (baseline: 38)"}
+> ```
 
 ## Execution Handoff
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -161,29 +161,31 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
 
-**4. Verification requirement scan:** Re-read the original prompt/spec. Did it request user verification, user feedback, user approval, or any form of human-in-the-loop confirmation? If yes: verify that at least one task has `requiresUserVerification: true` in its metadata and includes the standard verification block. If no such task exists, add one.
+**4. Verification requirement scan:** Answer this question with YES or NO:
+
+> Does the original prompt/spec require **any form of** user verification, user feedback, user confirmation, user approval, human sign-off, or human-in-the-loop validation of the work's outcome?
+
+This is about **intent**, not exact keywords. All of these qualify:
+- "plan must include user feedback on error count" → YES
+- "terugkoppeling van users hoeveel foutmeldingen die ziet" → YES
+- "verify with the user that latency improved" → YES
+- "add a caching layer" → NO (no human verification requested)
+
+**If YES:** Call `TaskList`. At least one task MUST have `requiresUserVerification: true` in its `json:metadata`. If no such task exists → you have a gap. **Do not proceed.** Create a dedicated verification task now using the standard format below.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 
-## User Verification Detection
+## User Verification Enforcement
 
-After writing the plan tasks but BEFORE creating native tasks, scan the original prompt/spec for user verification requirements.
+When the original prompt/spec requires any form of user verification (detected in Self-Review step 4 above), the plan MUST include dedicated verification task(s). This is not optional — it is the mechanism that ensures user feedback requirements survive from prompt through to execution.
 
-**Detection keywords** (match any of these in the prompt, spec, or task descriptions):
-- "user verification", "user approval", "user confirmation", "user feedback"
-- "ask the user", "confirm with user", "check with user", "verify with user"
-- "human review", "human approval", "manual verification"
-- "requires approval", "needs confirmation", "must confirm"
-- "feedback from users", "user reports", "user observes"
+### What makes a verification task
 
-**When verification keywords are detected:**
+A verification task has three mandatory elements:
 
-1. Create dedicated verification task(s) — or add verification to existing tasks if the verification is part of that task's scope
-2. Set `"requiresUserVerification": true` in the task's `json:metadata`
-3. Set `"userVerificationPrompt"` to the specific question for the user
-4. Include the **standard verification block** in the task description (copy verbatim):
-
-**Standard verification block format:**
+1. `"requiresUserVerification": true` in the task's `json:metadata`
+2. `"userVerificationPrompt"` set to the specific question for the user
+3. The **standard verification block** in the task description (copy verbatim):
 
 ~~~markdown
 **User Verification Required:**
@@ -202,9 +204,18 @@ AskUserQuestion:
 
 **If the user selects the negative option:** The task is NOT complete. Rework, then re-verify with AskUserQuestion again.
 
-**Example — prompt says "plan must include user feedback on error count":**
+### Where verification tasks go
 
-The plan should include a task like:
+- **Dedicated task** when the verification is a standalone checkpoint (e.g., "ask the user how many errors they see")
+- **Added to an existing task** when the verification is part of that task's scope (e.g., "implement fix AND verify with user that it works")
+
+Either way, the three mandatory elements above must be present.
+
+### Example
+
+Prompt: "Fix hook errors. Plan must include user feedback on error count."
+
+The plan must include a task like:
 
 > **Task N: Verify error reduction with user**
 >
@@ -226,6 +237,17 @@ The plan should include a task like:
 > ```json:metadata
 > {"files": [], "verifyCommand": "", "acceptanceCriteria": ["user confirms error reduction"], "requiresUserVerification": true, "userVerificationPrompt": "How many hook errors do you see per Bash command? (baseline: 38)"}
 > ```
+
+<HARD-GATE>
+STOP. Before proceeding to Execution Handoff, you MUST confirm:
+
+1. Did you complete Self-Review step 4 (verification requirement scan)?
+2. If the answer was YES (prompt requires user verification): does `TaskList` show at least one task with `requiresUserVerification: true` in its description?
+
+If the prompt requires user verification and NO verification task exists: **GO BACK.** Create the verification task now. You CANNOT proceed to Execution Handoff without it.
+
+This gate exists because user verification requirements routinely get lost between plan writing and execution. The only way to guarantee they survive is to encode them as native tasks with enforceable metadata.
+</HARD-GATE>
 
 ## Execution Handoff
 


### PR DESCRIPTION
PreToolUse hooks were echoing {"decision": "allow"} to stdout, which is the JSON format for Stop hooks, not PreToolUse hooks. Claude Code validates stdout JSON against the expected hook schema, rejects the mismatched format, and reports "hook error", but still allows the tool since exit code is 0.

For PreToolUse hooks, exit 0 with empty stdout is the correct "allow" behavior. Only exit 2 with a stderr message is needed for "block".