### PR TITLE
refactor(using-git-worktrees): wrap Claude Code native worktree tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Check that commands appear:
 
 1. **brainstorming** - Activates before writing code. Refines rough ideas through questions, explores alternatives, presents design in sections for validation. Saves design document.
 
-2. **using-git-worktrees** - Activates after design approval. Creates isolated workspace on new branch, runs project setup, verifies clean test baseline.
+2. **using-git-worktrees** - Activates after design approval. Enters isolated workspace via `EnterWorktree`, runs project setup, verifies clean test baseline.
 
 3. **writing-plans** - Activates with approved design. Breaks work into bite-sized tasks (2-5 minutes each). Every task has exact file paths, complete code, verification steps. *Creates native tasks with dependencies.*
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This fork integrates Claude Code-native features into the Superpowers workflow.
 | Native Task Management | v2.1.16+ | Dependency tracking, real-time progress visibility |
 | Structured Task Metadata | v2.1.16+ | Goal/Files/AC/Verify structure with embedded `json:metadata` |
 | Pre-commit Task Gate | v2.1.16+ | Plugin hook blocks `git commit` when tasks are incomplete |
+| User-Thrown Gate Enforcement | v2.1.16+ | `userGate` / `user-gate` tag + opt-in hooks force re-validation when Claude closes a user-ordered verification task (see "Recommended Configuration") |
 
 ## Visual Comparison
 
@@ -136,6 +137,51 @@ TaskCreate:
 
 The `json:metadata` block is embedded in the description because `TaskGet` returns the description but not the `metadata` parameter. This ensures metadata is always available — for `executing-plans` verification, `subagent-driven-development` dispatch, and `.tasks.json` cross-session resume.
 
+## User-Thrown Gate Enforcement — Optional Flow
+
+*Canonical design doc: [`docs/user-gate-flow.md`](docs/user-gate-flow.md). The section below is a reader-facing summary.*
+
+This flow addresses a recurring failure: the user says "add a gate" or "verify it works" without specifying **how**, the agent invents a verification method, then finds it expensive at execution time and walks around it — closing the gate with an inline shortcut. The fix is a three-layer architecture that *never bothers the user during planning* and only surfaces a forced question when the agent genuinely can't proceed without one.
+
+**The whole flow is opt-in.** It activates only when you register the hooks below in `.claude/settings.local.json`. The slash command sits dormant without the hook — installing it alone does nothing.
+
+### Design principle — don't bombard the user during planning
+
+Users who want questions will say "brainstorm". Users who ask for a gate during planning just want the work done, they don't want a four-question interrogation. So `writing-plans` is silent here: it applies the **stricter definition** of a gate and tags liberally. Better to over-tag and let the execution-time hook filter than to over-question the user mid-plan.
+
+### The three layers
+
+| Layer | When | What it does |
+|-------|------|--------------|
+| **Write-plan (silent tagging)** | Plan authoring | Detects gate-language in the brief ("verify", "prove", "gate", "first on one then all", "make sure", "don't proceed until"). Tags the resulting task with `userGate: true` + `tags: ["user-gate"]`. No user questions. Uses the stricter definition: strict user gates AND strict agent gates AND gray-in-between all get tagged. |
+| **Execute-plan (hard trigger via hook)** | Task close / stop | The PostToolUse + Stop hooks fire when a tagged task is closed. The agent must then assess each criterion and choose one of two paths (below). |
+| **`/specify-gate` slash command (dormant unless hook active)** | Execute-plan, only when the agent cannot proceed | Asked 3-4 structured questions to the user that lock down the HOW: observable outcome, proof mechanism, scope, failure policy. Produces a structured verify spec the agent consumes. |
+
+### Agent decision at execute time
+
+When a tagged task comes up, the agent asks itself: **do I know *how* to verify this?**
+
+- **"Verify the `/health` endpoint returns 200"** → the HOW is self-evident. Agent just hits the endpoint, captures the output, posts `AC: <criterion> — PROVEN BY <evidence>`. No slash command needed. The hook sees the proof and passes.
+- **"Check it works"** → the HOW is vague. Agent invokes `/specify-gate`, which asks the user the 3-4 minimal questions, then uses the answers to execute real verification. No silent invention, no inline shortcut.
+- **Write-plan explicitly flagged `requiresUserSpecification: true`** → same path: invoke `/specify-gate`, ask the user.
+
+The user is only interrupted at execute time, and only when the alternative is the agent making something up.
+
+### Activation
+
+Register both hooks in `.claude/settings.local.json` (see "Recommended Configuration" below for the exact JSON). Without them:
+- `writing-plans` still tags gates (harmless extra metadata).
+- `/specify-gate` still exists but is never triggered automatically.
+- Nothing enforces evidence at close — behavior is identical to vanilla.
+
+Install one hook or both. The PostToolUse hook catches per-task closures; the Stop hook catches end-of-plan "everything done" claims. They compose — both firing on the same session is fine.
+
+### Escape hatches
+
+Both hooks fail-open on errors and have env-var kill switches (`SUPERPOWERS_USERGATE_GUARD=0`, `SUPERPOWERS_USERGATE_STOP_GUARD=0`) for one-off session bypasses without editing settings.
+
+---
+
 ## What's Inside
 
 ### Skills Library
@@ -157,6 +203,10 @@ The `json:metadata` block is embedded in the description because `TaskGet` retur
 - **using-git-worktrees** - Parallel development branches
 - **finishing-a-development-branch** - Merge/PR decision workflow
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
+
+**User-Thrown Gates** (optional flow, see "User-Thrown Gate Enforcement" above)
+- **checking-gates** - Do-I-know-HOW self-check for user-gate tasks; runs verify + posts `AC:…PROVEN BY` evidence, or hands off to specifying-gates
+- **specifying-gates** - Interactive 4-question AskUserQuestion flow that locks down the HOW for a vague user-gate
 
 **Meta**
 - **writing-skills** - Create new skills following best practices (includes testing methodology)
@@ -225,6 +275,60 @@ Opt in via `.claude/settings.local.json`:
 ```
 
 See the header of `hooks/examples/pre-commit-check-tasks.sh` for how it parses the session transcript and which task states count as open.
+
+### Force Re-Validation on User-Thrown Gate Close
+
+Optional `PostToolUse` hook that blocks when Claude closes a **user-thrown gate** task without capturing concrete evidence for every acceptance criterion. A user-thrown gate is any task that carries `"userGate": true` or a `"user-gate"` entry in `tags` inside its `json:metadata` fence — set by `writing-plans` when the user explicitly asked for a verification step ("make sure to verify X", "add a gate", "prove it on one, then all").
+
+Non-gate tasks pass through silently. The hook only fires when `TaskUpdate` sets status to `completed`.
+
+Opt in via `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "TaskUpdate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/plugins/marketplaces/superpowers-extended-cc-marketplace/hooks/examples/post-task-complete-revalidate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+See the header of `hooks/examples/post-task-complete-revalidate.sh` for how it parses `json:metadata` and the `USER-ORDERED GATE` banner, and how the `SUPERPOWERS_USERGATE_GUARD=0` escape hatch works.
+
+### Re-Validate Gates on "Plan Complete" Claims
+
+Optional `Stop` hook that complements the PostToolUse hook above. It fires when Claude signals plan completion ("plan complete", "both gates passed", "implementation complete", etc.) but the transcript shows user-thrown gate tasks were closed without subsequent per-criterion proof. Requires Claude to post evidence in the form `AC: <criterion> — PROVEN BY <evidence>` before it can stop.
+
+Opt in via `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/plugins/marketplaces/superpowers-extended-cc-marketplace/hooks/examples/stop-revalidate-user-gates.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+See the header of `hooks/examples/stop-revalidate-user-gates.sh` for the full list of completion keywords and the `SUPERPOWERS_USERGATE_STOP_GUARD=0` escape hatch.
 
 ### Block Low-Context Stop Excuses
 

--- a/commands/gate-check.md
+++ b/commands/gate-check.md
@@ -1,0 +1,5 @@
+---
+description: "Run the 'do I know HOW?' self-check on a user-gate task and either execute its verification with captured evidence, or hand off to /specify-gate when the HOW is ambiguous. Dormant unless the user-gate opt-in hook is registered."
+---
+
+Invoke the superpowers-extended-cc:checking-gates skill and follow it exactly as presented to you. Target task: $ARGUMENTS

--- a/commands/specify-gate.md
+++ b/commands/specify-gate.md
@@ -1,0 +1,5 @@
+---
+description: "Lock down verification mechanics for a user-gate task whose HOW is ambiguous. Asks 4 short questions, writes the answers back into the task's metadata, then returns control to executing-plans. Dormant unless the user-gate hook is registered."
+---
+
+Invoke the superpowers-extended-cc:specifying-gates skill and follow it exactly as presented to you. Target task: $ARGUMENTS

--- a/docs/user-gate-flow.md
+++ b/docs/user-gate-flow.md
@@ -1,0 +1,242 @@
+# User-Thrown Gate Enforcement Flow
+
+Canonical design doc for the optional gate-enforcement flow. The README section "User-Thrown Gate Enforcement — Optional Flow" is a reader-facing summary; this file is the source of truth.
+
+## Problem
+
+Recurring failure mode observed in real sessions:
+
+1. User says "add a gate" / "verify it works" / "first on one then on all" — without specifying **how** the verification happens.
+2. Agent invents a verification method (pick a command, pick a subagent, pick an entity).
+3. At execution time the chosen method turns out expensive or annoying.
+4. Agent substitutes a cheaper check inline and closes the gate.
+5. User discovers later the gate was never actually run as intended.
+
+The fix must satisfy two competing constraints:
+
+- **Don't bombard the user during planning.** Users who want questions say "brainstorm". Mid-plan forms are friction. Tag, don't interrogate.
+- **Don't let the agent silently invent gate mechanics.** That's what got us here. Force a single, focused question moment at execution time — and only when the alternative is invention.
+
+Additional requirement: the whole enforcement apparatus is **opt-in**. Installing the plugin without enabling the hook must leave existing flows byte-for-byte unchanged.
+
+## Architecture — two loads: surgical (main flow) vs. activated (hook-gated)
+
+```
+  ┌──────────────────────────────────────────────────────────────┐
+  │   SURGICAL IMPROVEMENTS — always active, zero friction       │
+  │                                                              │
+  │   • writing-plans detects gate-language and tags the task    │
+  │     (userGate:true, tags:["user-gate"]).                     │
+  │   • executing-plans gains one rule: "run user-gate tasks     │
+  │     exactly as specified, capture output per AC, do not      │
+  │     substitute a cheaper check."                             │
+  │                                                              │
+  │   These are wins regardless of hook state. Extra metadata    │
+  │   is harmless. The executing-plans rule costs one paragraph. │
+  └──────────────────────────────────────────────────────────────┘
+
+  ┌──────────────────────────────────────────────────────────────┐
+  │   ACTIVATED FLOW — only when the opt-in hook is registered   │
+  │                                                              │
+  │   Hook (PostToolUse / Stop)                                  │
+  │     └─▶ /gate-check <task-id>   (do-I-know-HOW? self-check)  │
+  │            ├─▶ HOW clear      → run verify, post AC:…PROVEN  │
+  │            └─▶ HOW ambiguous  → /specify-gate <task-id>      │
+  │                                    ├─▶ 4 AskUserQuestion     │
+  │                                    └─▶ rewrite metadata      │
+  │                                    re-enter /gate-check      │
+  │                                                              │
+  │   Without the hook registered, /gate-check and /specify-gate │
+  │   sit dormant. Nothing forces them to run.                   │
+  └──────────────────────────────────────────────────────────────┘
+```
+
+### Why keep `/gate-check` out of executing-plans
+
+Earlier drafts tried to put the "do I know HOW?" self-check inline into `executing-plans`. That pollutes a general-purpose skill with enforcement logic only some users want. Extracting it into its own slash command + skill means:
+
+- Users without the hook installed get untouched `executing-plans`.
+- Users with the hook installed get a focused, scoped handler they can read end-to-end.
+- `executing-plans` keeps its short, generic shape and stays easy to reason about.
+
+## Hook ON / Hook OFF — the activation contract
+
+| State | What happens when executing-plans hits a user-gate task |
+|-------|----------------------------------------------------------|
+| **Hook ON** (registered in `.claude/settings.local.json`) | Hook stderr nudges the agent to run `/gate-check <task-id>`. That command runs the do-I-know-HOW self-check and either executes the verification with captured evidence or hands off to `/specify-gate`. Task closes only after `AC: <criterion> — PROVEN BY <evidence>` lines are posted. |
+| **Hook OFF** (default) | Regular `executing-plans` flow. The surgical improvements still apply (agent runs the verifyCommand as specified, captures output), but there is no forced routing, no slash command invocation, no interactive questioner. `/gate-check` and `/specify-gate` exist but are never auto-triggered. |
+
+**Crucial:** installing the plugin does not enable the flow. The flow activates only when you explicitly add the hook to `.claude/settings.local.json`. Remove the hook entry and the flow deactivates — the slash commands remain available for manual use but no longer run automatically.
+
+## Layer 1 — writing-plans (silent tagging)
+
+**Main flow, surgical.** Even without the hook.
+
+### Detection rules
+
+During write-plan, scan the brief and each task description for gate-language. Strict definition — tag liberally:
+
+- Verbs: `verify`, `prove`, `validate`, `confirm`, `ensure`, `check`, `gate`
+- Noun patterns: `verification gate`, `acceptance test`, `smoke test`, `end-to-end`, `E2E`
+- Scope patterns: `first on one`, `then all`, `one before the rest`, `before proceeding`, `don't continue until`
+- Proof-demand patterns: `prove it works`, `make sure`, `demonstrate`
+
+Tag any matching task with:
+
+```json
+{"userGate": true, "tags": ["user-gate"], ...}
+```
+
+Add the verbatim banner near the top of the description:
+
+> **USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation.
+
+### Three shades of gate
+
+The tag intentionally covers three cases:
+
+| Shade | Example | Tagged? |
+|-------|---------|---------|
+| Strict user gate | User says "add a verification gate before Task 5" | Yes |
+| Strict agent gate | Write-plan decides "this API change needs a smoke test" | Yes |
+| Gray in-between | Task description reads "confirm the migration ran" | Yes |
+
+Over-tagging is cheap (one extra metadata field, no user impact). Under-tagging is expensive (the whole reason this flow exists).
+
+### HOW-specification signal
+
+When the user's message specifies the HOW concretely (e.g., "verify `sensor.foo = idle`", "run `pytest tests/e2e.py`", "dispatch a Sonnet subagent against brief X"), encode it directly in `verifyCommand` and `acceptanceCriteria`. No further action needed at plan time.
+
+When the user's message leaves the HOW ambiguous ("check it works", "make sure it's fine"), set an additional metadata field:
+
+```json
+{"userGate": true, "tags": ["user-gate"], "requiresUserSpecification": true}
+```
+
+This flag is Layer 2's signal to invoke `/specify-gate` on first touch, regardless of the agent's self-assessment.
+
+**No user questions during write-plan.** The opinionated default is "tag it and move on".
+
+## Layer 2 — `/gate-check` (separate command, hook-activated)
+
+Runs the do-I-know-HOW? self-check in isolation and either executes the verification or routes to `/specify-gate`. Lives in `skills/checking-gates/SKILL.md`.
+
+### When it runs
+
+- The opt-in hook emitted stderr telling the agent to run it (auto).
+- The user invoked `/gate-check <task-id>` manually.
+- The agent chose to run it at start of a user-gate task (optional discipline when hook is active).
+
+### The do-I-know-HOW? rule
+
+A criterion has a clear HOW when all three hold:
+
+1. **Observable named** — sensor entity, HTTP endpoint, file path, log pattern, entity ID. Not "state", not "result".
+2. **Capture method named** — the command, API call, subagent, or direct read that produces the observable.
+3. **Pass/fail rule named** — an exact value, regex, or threshold. Not "reasonable" or "correct".
+
+If any of the three is missing for any criterion → the HOW is ambiguous → hand off to `/specify-gate`.
+
+**Err on the side of ambiguity.** Inventing a HOW silently is the exact failure this flow exists to prevent.
+
+### Evidence format
+
+After running the verification, post exactly this shape (the Stop hook and the PostToolUse hook both key off these markers):
+
+```
+Gate: <task subject>
+AC: <criterion 1> — PROVEN BY <command or excerpt of output>
+AC: <criterion 2> — PROVEN BY <...>
+```
+
+Then `TaskUpdate status=completed`.
+
+## Layer 3 — `/specify-gate` (separate command, interactive)
+
+Lives in `skills/specifying-gates/SKILL.md`. Asks the user 3–5 short AskUserQuestion questions (outcome / mechanism / scope / failure policy / optional subagent dispatch contract), rewrites the task's metadata fence, removes `requiresUserSpecification`, appends a human-readable Specification section to the task description, and returns control.
+
+Does NOT run verification. That's `/gate-check`'s job.
+
+## Hooks — activation layer
+
+Both opt-in via `.claude/settings.local.json`. See README "Recommended Configuration" for exact JSON.
+
+| Hook | Event | Trigger | Stderr message points at |
+|------|-------|---------|--------------------------|
+| `post-task-complete-revalidate.sh` | `PostToolUse` matcher=`TaskUpdate` | `status=completed` on a user-gate task without `AC:…PROVEN BY` evidence posted | `/gate-check <task-id>` |
+| `stop-revalidate-user-gates.sh` | `Stop` | Completion keywords ("plan complete", "both gates passed", …) + at least one closed user-gate task lacking evidence | `/gate-check <task-id>` |
+
+Both hooks fail-open on error. Escape hatches: `SUPERPOWERS_USERGATE_GUARD=0`, `SUPERPOWERS_USERGATE_STOP_GUARD=0`.
+
+## End-to-end example — hook ON
+
+User's original brief: *"Build the zoo, verify it works on one instance first, then on all."*
+
+**Layer 1 — writing-plans output (silent):**
+
+- Task 7: E2E on one instance
+  ```json
+  {"userGate": true, "tags": ["user-gate"], "requiresUserSpecification": true, "gateScope": "one"}
+  ```
+  (Brief mentions "verify" + vague HOW → flagged for user specification)
+
+- Task 8: E2E on all instances (blocked by #7)
+  ```json
+  {"userGate": true, "tags": ["user-gate"], "requiresUserSpecification": true, "gateScope": "all"}
+  ```
+
+No user questions asked. Plan is written and saved.
+
+**Layer 2 — executing-plans reaches Task 7:**
+
+1. Agent marks Task 7 `in_progress`.
+2. Hook is active → agent runs `/gate-check 7`.
+3. `/gate-check` loads metadata, sees `requiresUserSpecification: true`, hands off to `/specify-gate 7`.
+
+**Layer 3 — `/specify-gate 7`:**
+
+Four questions. User answers:
+- **Outcome:** "`sensor.marstek_battery_<suffix>_optimization_status` reads `idle` AND JIT notification fires within 10s of recalculate"
+- **Mechanism:** "Sonnet subagent using `instances/<tag>/seed-briefing.md` as prompt"
+- **Scope:** "one instance per minor version"
+- **Failure:** "reopen the task, do not block the plan"
+- **Subagent brief:** *(user pastes the briefing template)*
+
+Metadata updated, `requiresUserSpecification` removed. Returns control to `/gate-check 7`.
+
+**Back in `/gate-check 7`:**
+
+HOW is now concrete on all three axes. Dispatch the Sonnet subagent, capture the real output, post:
+
+```
+Gate: Task 7 E2E on one instance
+AC: sensor optimization_status = idle — PROVEN BY curl /api/states/sensor.marstek_battery_a3f1_optimization_status → "idle"
+AC: JIT notification fires within 10s — PROVEN BY notification_message diff, ts delta 5.2s
+```
+
+`TaskUpdate status=completed`. Hook sees the AC evidence in subsequent text, does not block. Gate is genuinely verified.
+
+**If the hook had been OFF:** Step 2 above skips. Agent reads the task description, runs it as specified (surgical main-flow rule), captures output — or quietly substitutes a cheaper check if it feels like it. Exactly the pre-flow behavior, minus one paragraph of discipline added to executing-plans.
+
+## What this does NOT do
+
+- Does not turn every task into a gate. Only tasks matching gate-language triggers.
+- Does not force questions during planning. L1 is silent.
+- Does not enforce anything if the hooks aren't installed. Pure opt-in.
+- Does not replace `brainstorming`. Brainstorming explores design; this flow nails down verification mechanics at the latest moment when they matter (execute time).
+- Does not modify `executing-plans` decision logic. Executing-plans gains one surgical paragraph ("run gates as specified") and nothing else.
+
+## Open work
+
+All design-doc open items have been delivered:
+
+- ✅ Gate-language detector step in `writing-plans` Step 1 (mechanical keyword table).
+- ✅ `requiresUserSpecification`, `gateScope`, `failurePolicy`, `subagentBrief` rows added to the metadata table.
+- ✅ End-to-end integration test at `tests/claude-code/test-user-gate-hooks.sh` (10 test cases including idempotency regression).
+- ✅ README section distinguishes surgical (always-on) vs. activated (hook-gated) improvements.
+- ✅ Per-task isolation self-check added to `writing-plans` Step 5 (catches the "sibling-bleed" pattern where concrete per-op context masks a vague final task).
+
+### Remaining quality questions (not blocking)
+
+- **`requiresUserSpecification` fire rate:** 0/1 in the single live opus-4.7 session. Step 5 self-check targets this; effectiveness is unverified — needs 2-3 more live sessions with varied vague phrasings to confirm.
+- **Multi-harness testing:** only exercised on Claude Code via Opus 4.7. Sonnet/Haiku behavior, and Cursor/Gemini/Codex harness behavior, untested.

--- a/hooks/examples/post-task-complete-revalidate.sh
+++ b/hooks/examples/post-task-complete-revalidate.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# PostToolUse hook: when a USER-THROWN gate task is closed, force Claude to
+# re-state evidence before moving on.
+#
+# Add this to your project's .claude/settings.local.json (see README).
+#
+# ## What it does
+#
+# Triggers on TaskUpdate tool calls with status=completed. Looks up the
+# task's description in the session transcript and parses the embedded
+# `json:metadata` fence. If metadata says the task is a user-thrown gate —
+# `userGate: true` OR `tags` contains `"user-gate"` — emits a blocking
+# reminder (exit 2 + stderr) that forces Claude to confirm every
+# acceptanceCriteria with concrete evidence in the next turn.
+#
+# Regular (non-gate) tasks pass through silently.
+#
+# ## Why PostToolUse (not PreToolUse)
+#
+# The close itself is allowed — a user-gate task *can* legitimately be
+# completed. What the hook protects against is closing-and-moving-on
+# without proof. PostToolUse fires after the tool succeeds, so the block
+# is a system-reminder the model MUST address before its next action,
+# not a refusal to close the task.
+#
+# ## Escape hatch
+#
+# Set SUPERPOWERS_USERGATE_GUARD=0 to disable at runtime. The hook is
+# opt-in already, so an escape hatch exists mainly for subagent contexts
+# where re-validation has already happened upstream.
+
+if [[ "${SUPERPOWERS_USERGATE_GUARD:-1}" == "0" ]]; then
+    exit 0
+fi
+
+# Fail-open: if anything unexpected breaks, never block.
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[[ "$TOOL_NAME" != "TaskUpdate" ]] && exit 0
+
+STATUS=$(echo "$INPUT" | jq -r '.tool_input.status // empty' 2>/dev/null)
+[[ "$STATUS" != "completed" ]] && exit 0
+
+TASK_ID=$(echo "$INPUT" | jq -r '.tool_input.taskId // empty' 2>/dev/null)
+[[ -z "$TASK_ID" ]] && exit 0
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
+
+# Walk the transcript JSONL to find the TaskCreate (and any later TaskUpdate)
+# for this taskId, extract the description, and parse the json:metadata fence.
+# Python (no heredoc — avoids bash 5.3 heredoc-hang regression).
+PY_PARSE='
+import json, re, sys
+path = sys.argv[1]
+task_id = str(sys.argv[2])
+
+description = ""
+subject = ""
+# IDs are 1-based and increment in creation order. Rebuild that counter as we
+# walk the transcript so we can match TaskCreate calls (which do not carry
+# taskId in their input) to the target taskId.
+next_id = 1
+# Track line indices for the scan window below: where the most recent
+# in_progress status change occurred for this taskId, and all assistant-text
+# messages. If evidence already appears between in_progress and the close,
+# the hook should NOT re-fire — that is what "already validated" means.
+last_inprogress_idx = -1
+text_indices = []  # list of (line_idx, text)
+
+try:
+    with open(path) as f:
+        lines = f.readlines()
+except Exception:
+    print(json.dumps({}))
+    sys.exit(0)
+
+for idx, line in enumerate(lines):
+    try:
+        entry = json.loads(line)
+    except Exception:
+        continue
+    if entry.get("type") != "assistant":
+        continue
+    msg = entry.get("message") or {}
+    for c in msg.get("content") or []:
+        if not isinstance(c, dict):
+            continue
+        if c.get("type") == "text":
+            txt = c.get("text", "") or ""
+            if txt.strip():
+                text_indices.append((idx, txt))
+            continue
+        if c.get("type") != "tool_use":
+            continue
+        name = c.get("name", "")
+        inp = c.get("input") or {}
+        if name == "TaskCreate":
+            if str(next_id) == task_id:
+                description = inp.get("description", "") or ""
+                subject = inp.get("subject", "") or ""
+            next_id += 1
+        elif name == "TaskUpdate":
+            tid = str(inp.get("taskId", ""))
+            if tid == task_id:
+                if inp.get("description"):
+                    description = inp.get("description", "") or ""
+                if inp.get("status") == "in_progress":
+                    last_inprogress_idx = idx
+            try:
+                if int(tid) >= next_id:
+                    next_id = int(tid) + 1
+            except (ValueError, TypeError):
+                pass
+
+out = {"subject": subject, "userGate": False, "tags": [],
+       "criteria": [], "evidence_on_record": False}
+
+# Parse the `json:metadata` code fence inside the task description.
+m = re.search(r"```json:metadata\s*\n(.*?)\n```", description, re.DOTALL)
+if m:
+    try:
+        meta = json.loads(m.group(1))
+        out["userGate"] = bool(meta.get("userGate", False))
+        tags = meta.get("tags", [])
+        out["tags"] = tags if isinstance(tags, list) else []
+        crits = meta.get("acceptanceCriteria", [])
+        out["criteria"] = crits if isinstance(crits, list) else []
+    except Exception:
+        pass
+
+# Also count a task as a gate if the description carries the verbatim
+# USER-ORDERED GATE banner, even when the metadata fence is missing.
+if "USER-ORDERED GATE" in description.upper():
+    out["userGate"] = True
+
+# Evidence scan: if at least one assistant-text message between the most
+# recent in_progress for this task and now contains an AC:/PROVEN BY
+# marker, treat the close as already validated. Scope the window to the
+# in_progress marker to avoid counting evidence from a *different* gate.
+# If no in_progress was seen (agent skipped straight to completed), fall
+# back to scanning the whole transcript.
+scan_from = last_inprogress_idx if last_inprogress_idx >= 0 else 0
+ac_re = re.compile(r"\bAC\s*:", re.IGNORECASE)
+pb_re = re.compile(r"\bPROVEN\s+BY\b", re.IGNORECASE)
+for (i, txt) in text_indices:
+    if i < scan_from:
+        continue
+    if ac_re.search(txt) or pb_re.search(txt):
+        out["evidence_on_record"] = True
+        break
+
+print(json.dumps(out))
+'
+
+RESULT=$(python3 -c "$PY_PARSE" "$TRANSCRIPT_PATH" "$TASK_ID" 2>/dev/null || echo "{}")
+
+IS_GATE=$(echo "$RESULT" | jq -r '
+    (.userGate == true) or ((.tags // []) | any(. == "user-gate"))
+' 2>/dev/null)
+
+[[ "$IS_GATE" != "true" ]] && exit 0
+
+# Idempotency: if evidence (AC:/PROVEN BY markers) is already on record for
+# this task since its most recent in_progress transition, the re-close is
+# legitimate and the hook should stay silent. Without this check the hook
+# loops after /gate-check has already posted evidence.
+EVIDENCE_ON_RECORD=$(echo "$RESULT" | jq -r '.evidence_on_record // false' 2>/dev/null)
+[[ "$EVIDENCE_ON_RECORD" == "true" ]] && exit 0
+
+SUBJECT=$(echo "$RESULT" | jq -r '.subject // "(unknown)"' 2>/dev/null)
+CRITERIA_JSON=$(echo "$RESULT" | jq -c '.criteria // []' 2>/dev/null)
+
+{
+    echo "USER-GATE CLOSED — RE-VALIDATION REQUIRED"
+    echo
+    echo "Task #$TASK_ID ('$SUBJECT') is a USER-ORDERED gate. You just closed it."
+    echo
+    echo "The correct recovery path is to reopen the task and route it through"
+    echo "the user-gate flow:"
+    echo
+    echo "    1. TaskUpdate taskId=$TASK_ID status=in_progress"
+    echo "    2. /gate-check $TASK_ID"
+    echo
+    echo "/gate-check runs the 'do I know HOW?' self-check, then either executes"
+    echo "the verification with captured evidence OR hands off to /specify-gate"
+    echo "when the HOW is ambiguous. It posts one line per acceptance criterion:"
+    echo "    AC: <criterion> — PROVEN BY <evidence>"
+    echo
+    echo "Acceptance criteria on record:"
+    echo "$CRITERIA_JSON" | jq -r '.[] | "  - " + .' 2>/dev/null || true
+    echo
+    echo "If /gate-check is not installed in this harness, post the AC: lines"
+    echo "inline by running the verification yourself. Either way, do NOT move"
+    echo "on without concrete evidence per criterion."
+    echo "(To disable this check, set SUPERPOWERS_USERGATE_GUARD=0.)"
+} >&2
+
+exit 2

--- a/hooks/examples/stop-revalidate-user-gates.sh
+++ b/hooks/examples/stop-revalidate-user-gates.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Stop hook: when Claude signals "plan complete / all gates passed" but a
+# user-thrown gate was closed without captured evidence, block stop and
+# require a final re-validation sweep.
+#
+# Add this to your project's .claude/settings.local.json (see README).
+#
+# ## What it does
+#
+# Fires on the Stop event. Two conditions must BOTH hold to block:
+#
+#   1. The last assistant message contains a "completion" keyword
+#      (e.g. "plan complete", "implementation complete", "all gates passed",
+#      "both gates passed", "all tasks complete", "plan 0–7 done").
+#
+#   2. The session transcript contains at least one TaskUpdate to
+#      status=completed for a task whose description is a user-thrown gate
+#      (metadata `userGate: true`, OR metadata `tags` contains `"user-gate"`,
+#      OR description carries the verbatim "USER-ORDERED GATE" banner), AND
+#      no subsequent assistant message surfaces explicit per-criterion
+#      proof (patterns like "AC:", "PROVEN BY").
+#
+# When both hold, the hook emits a blocking stderr message (exit 2) naming
+# the gates that lack evidence. Claude must then produce the proof before
+# stopping again.
+#
+# ## Why Stop (not PostToolUse)
+#
+# PostToolUse already has a sibling hook (post-task-complete-revalidate.sh)
+# that catches individual closes. This Stop hook is the net underneath —
+# it catches end-of-plan claims ("both gates passed") even when per-task
+# closure moved through legitimate-looking paths.
+#
+# ## Escape hatch
+#
+# Set SUPERPOWERS_USERGATE_STOP_GUARD=0 to disable at runtime.
+
+if [[ "${SUPERPOWERS_USERGATE_STOP_GUARD:-1}" == "0" ]]; then
+    exit 0
+fi
+
+# Fail-open: never cascade errors into the user's session.
+trap 'exit 0' ERR
+
+INPUT=$(cat)
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
+
+# Walk the transcript: find all TaskCreate + TaskUpdate calls, identify
+# which completed tasks are user-thrown gates, and look for per-criterion
+# proof in assistant text AFTER the close.
+PY_SCAN='
+import json, re, sys
+path = sys.argv[1]
+
+tasks = {}           # id -> {"subject", "description", "status",
+                     #        "userGate", "tags", "closedAtIdx"}
+last_text = ""
+assistant_texts = []  # (line_idx, text)
+
+try:
+    with open(path) as f:
+        lines = f.readlines()
+except Exception:
+    print(json.dumps({"blocked_gates": [], "last_text": "", "proofs": []}))
+    sys.exit(0)
+
+next_id = 1
+for idx, line in enumerate(lines):
+    try:
+        entry = json.loads(line)
+    except Exception:
+        continue
+    if entry.get("type") != "assistant":
+        continue
+    msg = entry.get("message") or {}
+    for c in msg.get("content") or []:
+        if not isinstance(c, dict):
+            continue
+        if c.get("type") == "text":
+            txt = c.get("text", "") or ""
+            if txt.strip():
+                assistant_texts.append((idx, txt))
+                last_text = txt
+        elif c.get("type") == "tool_use":
+            name = c.get("name", "")
+            inp = c.get("input") or {}
+            if name == "TaskCreate":
+                tasks[str(next_id)] = {
+                    "subject": inp.get("subject", ""),
+                    "description": inp.get("description", "") or "",
+                    "status": "pending",
+                    "userGate": False,
+                    "tags": [],
+                    "closedAtIdx": None,
+                }
+                next_id += 1
+            elif name == "TaskUpdate":
+                tid = str(inp.get("taskId", ""))
+                if tid in tasks:
+                    if inp.get("description"):
+                        tasks[tid]["description"] = inp["description"]
+                    if inp.get("subject"):
+                        tasks[tid]["subject"] = inp["subject"]
+                    new_status = inp.get("status")
+                    if new_status:
+                        tasks[tid]["status"] = new_status
+                        if new_status == "completed":
+                            tasks[tid]["closedAtIdx"] = idx
+                try:
+                    if int(tid) >= next_id:
+                        next_id = int(tid) + 1
+                except (ValueError, TypeError):
+                    pass
+
+# Classify each completed task.
+for tid, t in tasks.items():
+    desc = t["description"]
+    m = re.search(r"```json:metadata\s*\n(.*?)\n```", desc, re.DOTALL)
+    if m:
+        try:
+            meta = json.loads(m.group(1))
+            t["userGate"] = bool(meta.get("userGate", False))
+            tags = meta.get("tags", [])
+            if isinstance(tags, list):
+                t["tags"] = tags
+        except Exception:
+            pass
+    if "USER-ORDERED GATE" in desc.upper():
+        t["userGate"] = True
+
+# Completion keywords in the last assistant text — broad enough to catch
+# the language models actually use when declaring a plan finished.
+keywords = [
+    "plan complete",
+    "plan is complete",
+    "plan finished",
+    "implementation complete",
+    "implementation is complete",
+    "all tasks complete",
+    "all tasks done",
+    "all gates passed",
+    "both gates passed",
+    "both gates pass",
+    "gate passed",
+    "gate passes",
+    "verification gate — passes",
+    "verification gate passed",
+    "plan 0",  # catches "Plan 0-7 done" style
+    "tasks 0",  # catches "Tasks 0-7 + Gate 1 done"
+]
+low = last_text.lower()
+has_completion_claim = any(k in low for k in keywords)
+
+blocked_gates = []
+if has_completion_claim:
+    for tid, t in tasks.items():
+        if t["status"] != "completed":
+            continue
+        is_gate = t["userGate"] or ("user-gate" in (t["tags"] or []))
+        if not is_gate:
+            continue
+        # Look for per-criterion proof markers in assistant text after close.
+        proof_found = False
+        close_idx = t["closedAtIdx"] or 0
+        for (i, txt) in assistant_texts:
+            if i <= close_idx:
+                continue
+            # "AC:" prefix or "PROVEN BY" marker = explicit evidence.
+            if re.search(r"\bAC\s*:", txt, re.IGNORECASE) or \
+               re.search(r"\bPROVEN\s+BY\b", txt, re.IGNORECASE):
+                proof_found = True
+                break
+        if not proof_found:
+            blocked_gates.append({"id": tid, "subject": t["subject"]})
+
+print(json.dumps({
+    "has_completion_claim": has_completion_claim,
+    "blocked_gates": blocked_gates,
+    "total_tasks": len(tasks),
+}))
+'
+
+RESULT=$(python3 -c "$PY_SCAN" "$TRANSCRIPT_PATH" 2>/dev/null || echo "{}")
+
+BLOCKED_COUNT=$(echo "$RESULT" | jq -r '.blocked_gates | length // 0' 2>/dev/null)
+
+if [[ "${BLOCKED_COUNT:-0}" -le 0 ]]; then
+    exit 0
+fi
+
+{
+    echo "PLAN-COMPLETE CLAIM DETECTED BUT USER-GATE EVIDENCE MISSING"
+    echo
+    echo "You signalled the plan / gates as complete, but the transcript shows"
+    echo "$BLOCKED_COUNT user-thrown gate(s) closed without per-criterion proof in"
+    echo "your subsequent text. Gates missing evidence:"
+    echo
+    echo "$RESULT" | jq -r '.blocked_gates[] | "  - Task #" + .id + ": " + .subject' 2>/dev/null || true
+    echo
+    echo "Before stopping, reopen each listed gate and run /gate-check on it:"
+    echo
+    echo "    1. TaskUpdate taskId=<id> status=in_progress"
+    echo "    2. /gate-check <id>"
+    echo
+    echo "/gate-check posts evidence in the shape this hook recognises:"
+    echo
+    echo "  Gate: <subject>"
+    echo "  AC: <criterion> — PROVEN BY <exact command/output/subagent result>"
+    echo "  AC: <criterion> — PROVEN BY <...>"
+    echo
+    echo "If /gate-check is not installed, post the AC: lines inline by running"
+    echo "the verification yourself. If a gate cannot be proven right now,"
+    echo "reopen it and retract the completion claim above."
+    echo "(To disable this check, set SUPERPOWERS_USERGATE_STOP_GUARD=0.)"
+} >&2
+
+exit 2

--- a/skills/checking-gates/SKILL.md
+++ b/skills/checking-gates/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: checking-gates
+description: Use when picking up a user-gate task OR when a hook demands re-validation. Runs the "do I know HOW?" self-check; if the HOW is clear, executes the verification and posts evidence; if not, hands off to specifying-gates. Kept deliberately separate from executing-plans so that without the opt-in hook, the main flow stays untouched.
+---
+
+# Checking User-Thrown Gates
+
+## Why this skill is separate from executing-plans
+
+User-gate enforcement is an **opt-in flow**. When the opt-in hook is not registered, executing-plans runs unchanged — no extra checks, no extra context, no extra questions. When the hook IS registered, it routes user-gate tasks through this skill. Keeping the decision logic in a separate skill means:
+
+- Users who don't want the flow get zero friction.
+- Users who do want it get a focused, scoped handler.
+- `executing-plans` stays short and readable.
+
+## When to invoke
+
+Any one of:
+
+1. You are about to start a task whose `json:metadata` has `"userGate": true` or whose `tags` contains `"user-gate"` AND the opt-in hook is active (see the README for how to detect this — if you were invoked via `/gate-check`, the hook is active by definition).
+2. A hook fired stderr telling you to run `/gate-check <task-id>`.
+3. The user manually ran `/gate-check <task-id>`.
+
+If none of these apply, return to executing-plans without running this skill.
+
+**Announce at start:** "I'm using the checking-gates skill to verify Task N's acceptance criteria."
+
+## The three-step process
+
+### Step 1 — Load and classify
+
+1. `TaskGet <task-id>` — read the full description.
+2. Parse the `json:metadata` fence.
+3. Classify:
+   - `requiresUserSpecification: true` → go to Step 2 path A.
+   - Concrete `verifyCommand` + every `acceptanceCriteria` names an observable (sensor, HTTP status, file, log line, entity) → go to Step 2 path B.
+   - Vague criteria ("it works", "is fine", "as expected", "properly") or missing `verifyCommand` → go to Step 2 path A.
+
+### Step 2 — Route
+
+**Path A — HOW is ambiguous.** Invoke `specifying-gates` (or tell the user to run `/specify-gate <task-id>`). Stop. Let that skill lock down the mechanics. When it returns, re-enter this skill from Step 1.
+
+**Path B — HOW is clear.** Continue to Step 3.
+
+### Step 3 — Execute and post evidence
+
+1. Run the `verifyCommand` (or dispatch the subagent with `subagentBrief`). Capture exact output.
+2. Map each `acceptanceCriteria` entry to an observable in the output.
+3. Post one block of text back to the user, using EXACTLY this format (the sibling hooks key off the `AC:` + `PROVEN BY` markers):
+
+   ```
+   Gate: <task subject>
+   AC: <criterion 1> — PROVEN BY <command or excerpt of output>
+   AC: <criterion 2> — PROVEN BY <...>
+   ...
+   ```
+
+4. If every criterion passed → `TaskUpdate status=completed`.
+5. If any criterion failed → look up `failurePolicy`:
+   - `"stop-plan"` → leave the task `in_progress`, surface the failure to the user, stop.
+   - `"reopen-continue"` → leave the task `in_progress`, move to the next unblocked task.
+   - `"log-continue"` → post the failure inline, mark completed anyway, continue.
+
+## Do-I-know-HOW self-check — the short version
+
+A criterion has a clear HOW when all three hold:
+
+1. **Observable named** — sensor entity, HTTP endpoint, file path, log pattern, entity ID. Not "state", not "result".
+2. **Capture method named** — the command, API call, subagent, or direct read that produces the observable.
+3. **Pass/fail rule named** — an exact value, regex, or threshold. Not "reasonable" or "correct".
+
+If any of the three is missing for any criterion, HOW is NOT clear → Path A.
+
+**Err on the side of Path A.** Inventing a HOW silently is the exact failure this flow exists to prevent.
+
+## What NOT to do
+
+- Do NOT modify executing-plans' behavior from inside this skill. This skill is a leaf — it returns control when done.
+- Do NOT invoke `EnterPlanMode` or `ExitPlanMode`.
+- Do NOT substitute a cheaper verification for the one specified. If you think the spec is wrong, reopen via `/specify-gate` — don't walk around it.
+- Do NOT close the task if any criterion lacks concrete evidence. "Looks fine" is not evidence.
+
+## Integration
+
+- **Invoked from:** the PostToolUse / PreToolUse user-gate hook; or `/gate-check` slash command.
+- **May hand off to:** `specifying-gates` (Path A).
+- **Returns to:** `executing-plans` (or wherever it was invoked from) after TaskUpdate.
+- **References:** `skills/shared/task-format-reference.md` for metadata schema.

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -67,8 +67,12 @@ For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. **Use metadata for verification:** Parse the `json:metadata` code fence from the task description. Run `verifyCommand` and check each `acceptanceCriteria` before marking complete.
-4. Mark as completed
-5. **Sync `.tasks.json`:** Read the tasks file, update the task's `"status"` to `"completed"` (or `"in_progress"` in step 1), set `"lastUpdated"` to current ISO timestamp, write back. This keeps the persistence file in sync with native tasks for cross-session resume.
+4. **User-thrown gates are non-skippable.** If the task's metadata has `"userGate": true` OR its `tags` array contains `"user-gate"`, you MUST:
+   - Execute the gate exactly as specified — no inline shortcut, no cheaper substitute, no "I already verified this informally".
+   - Capture concrete output for every entry in `acceptanceCriteria` (command output, entity state, log line, subagent result).
+   - If any criterion cannot be proven right now, leave the task `in_progress` and surface the blocker to the user. Do NOT close it.
+5. Mark as completed
+6. **Sync `.tasks.json`:** Read the tasks file, update the task's `"status"` to `"completed"` (or `"in_progress"` in step 1), set `"lastUpdated"` to current ISO timestamp, write back. This keeps the persistence file in sync with native tasks for cross-session resume.
 
 ### Step 3: Complete Development
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -197,4 +197,4 @@ git worktree remove <worktree-path>
 - **executing-plans** (Step 5) - After all batches complete
 
 **Pairs with:**
-- **using-git-worktrees** - Cleans up worktree created by that skill
+- **using-git-worktrees** - Cleans up worktree created by that skill (delegates to native `ExitWorktree`)

--- a/skills/shared/task-format-reference.md
+++ b/skills/shared/task-format-reference.md
@@ -37,6 +37,49 @@ Embed metadata as a `json:metadata` code fence at the end of the TaskCreate desc
 | `verifyCommand` | string | yes | Command to verify task completion |
 | `acceptanceCriteria` | string[] | yes | List of testable criteria |
 | `estimatedScope` | "small" \| "medium" \| "large" | no | Relative effort indicator |
+| `userGate` | boolean | no | `true` when the user explicitly requested this task as a verification gate. Signals to hooks and reviewers that the task is USER-ORDERED and MUST NOT be closed until its `acceptanceCriteria` have been re-validated independently. See "User-Thrown Gates" below. |
+| `tags` | string[] | no | Free-form tags (e.g. `["user-gate", "verification"]`). Opt-in hooks key off tags like `user-gate` to trigger re-validation on close. |
+| `requiresUserSpecification` | boolean | no | Set by `writing-plans` when the user's brief says WHAT should be verified but not HOW. Signals to `/gate-check` that it must hand off to `/specify-gate` before running verification. Removed automatically once `/specify-gate` has captured the HOW. |
+| `gateScope` | "once" \| "per-target" \| "one-then-all" \| string | no | How many times / across how many targets the gate should run. Set by `/specify-gate` (Q3). Free-form string allowed for custom rules. |
+| `failurePolicy` | "stop-plan" \| "reopen-continue" \| "log-continue" | no | What happens if the gate fails. Set by `/specify-gate` (Q4). |
+| `subagentBrief` | string | no | Exact prompt/briefing for the dispatch subagent when the gate's proof mechanism is "subagent". Set by `/specify-gate` (Q5). Agent MUST pass this verbatim at dispatch — substituting a shorter version defeats the purpose. |
+
+## User-Thrown Gates
+
+A **user-thrown gate** is a verification task the user *explicitly asked for in the conversation* — not a check you invented while decomposing the plan. Typical signals in the user's message: "make sure to verify X before moving on", "add a gate", "run the full end-to-end before closing", "don't proceed until Y is proven", "first on one, then on all".
+
+When you create such a task, set BOTH:
+- `userGate: true`
+- `tags: ["user-gate"]` (append, do not replace existing tags)
+
+And add a mandatory line in the task description, verbatim:
+
+> **USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation. It MUST NOT be closed by walking around it, by declaring it "verified inline", or by substituting a cheaper check. Close only after every item in `acceptanceCriteria` has been re-validated independently, with output captured.
+
+Why both the flag and the prose: the prose protects the current session (visible to TaskGet), the flag protects future hooks and subagents that parse metadata.
+
+### Example — user-thrown gate
+
+```yaml
+TaskCreate:
+  subject: "Gate 1: End-to-end verification on one instance"
+  description: |
+    **Goal:** Prove the full pipeline works on exactly ONE instance before scaling to all.
+
+    **USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation. It MUST NOT be closed by walking around it, by declaring it "verified inline", or by substituting a cheaper check. Close only after every item in `acceptanceCriteria` has been re-validated independently, with output captured.
+
+    **Acceptance Criteria:**
+    - [ ] Fresh instance spun up from scratch
+    - [ ] Sonnet subagent dispatched with its briefing (no inline shortcut)
+    - [ ] JIT event captured in notification_message
+    - [ ] Manager scrape shows the event
+
+    **Verify:** `./zoo.sh status <tag>` + `cat logs/<tag>.jsonl | tail -1`
+
+    ```json:metadata
+    {"files": [], "verifyCommand": "./zoo.sh status v0.1.15 && cat logs/v0.1.15.jsonl | tail -1", "acceptanceCriteria": ["Fresh instance spun up from scratch", "Sonnet subagent dispatched with its briefing", "JIT event captured in notification_message", "Manager scrape shows the event"], "userGate": true, "tags": ["user-gate", "verification"]}
+    ```
+```
 
 ### Example
 

--- a/skills/specifying-gates/SKILL.md
+++ b/skills/specifying-gates/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: specifying-gates
+description: Use when a user-gate task has requiresUserSpecification=true OR the agent's "do I know HOW?" self-check returns no. Locks down verification mechanics through a short AskUserQuestion sequence and writes the answers back into the task's metadata. Does NOT run the verification itself.
+---
+
+# Specifying User-Thrown Gates
+
+## When this skill runs
+
+Exactly one of:
+
+1. A user-gate task has `"requiresUserSpecification": true` in its `json:metadata` fence, OR
+2. The agent ran the "do I know HOW?" self-check (see `executing-plans`) and concluded the verification mechanics are ambiguous, OR
+3. The user ran `/specify-gate <task-id>` manually.
+
+In all other cases — where `verifyCommand` is concrete and every `acceptanceCriteria` has an observable proof — the agent executes the gate directly and does NOT invoke this skill.
+
+**Announce at start:** "I'm using the specifying-gates skill to lock down verification mechanics for Task N."
+
+## CRITICAL — what this skill does NOT do
+
+- Does not run the verification command. Specification only.
+- Does not close the task. It only enriches metadata; the agent returns to `executing-plans` afterward.
+- Does not re-run brainstorming. The design is already decided; only the HOW of one gate is missing.
+
+## Input
+
+The target task ID. Resolved from the command argument or from the currently-in-progress user-gate task.
+
+Load the task with `TaskGet` and parse the `json:metadata` fence from its description.
+
+## The four questions
+
+Use `AskUserQuestion` — one question at a time per the brainstorming skill's rule.
+
+### Q1 — Observable outcome
+
+```yaml
+AskUserQuestion:
+  question: "Gate: <task subject>. What exact state proves this works? One line per criterion. 'It works' is not an answer — name a sensor, HTTP status, log line, file presence, or equivalent."
+  header: "Gate outcome"
+  options:
+    - label: "I'll type the criteria"
+      description: "Write 1-5 concrete, observable conditions"
+    - label: "Copy from task's acceptanceCriteria"
+      description: "Use the existing list (only if it's already concrete)"
+```
+
+Store the user's free-text answer as a list of strings in `acceptanceCriteria`. If any entry is vague (contains "works", "fine", "as expected", "properly" without a concrete target), push back and ask them to name the observable.
+
+### Q2 — Proof mechanism
+
+```yaml
+AskUserQuestion:
+  question: "How should the agent capture that state?"
+  header: "Mechanism"
+  options:
+    - label: "CLI command"
+      description: "A shell command whose output shows the criterion"
+    - label: "REST / API call"
+      description: "HTTP request, inspect response"
+    - label: "Subagent with briefing"
+      description: "Dispatch Sonnet or Haiku with a prompt template"
+    - label: "Direct inspection"
+      description: "Read a file, query an entity, check a log"
+```
+
+If "Subagent with briefing" → ask Q5 (dispatch contract) before proceeding.
+
+### Q3 — Scope
+
+```yaml
+AskUserQuestion:
+  question: "Run this once, or over multiple targets?"
+  header: "Scope"
+  options:
+    - label: "Once"
+      description: "Single execution, single target"
+    - label: "Per instance / target"
+      description: "Run identically across a list (e.g. all environments)"
+    - label: "First on one, then on all"
+      description: "Prove it on one target, then roll out to the rest — the classic two-gate pattern"
+    - label: "Custom"
+      description: "Describe the rule in free text"
+```
+
+Store as `gateScope`: `"once"` | `"per-target"` | `"one-then-all"` | custom string.
+
+### Q4 — Failure policy
+
+```yaml
+AskUserQuestion:
+  question: "If the gate fails, what happens?"
+  header: "On failure"
+  options:
+    - label: "Stop the plan (Recommended)"
+      description: "No further tasks until this gate passes"
+    - label: "Reopen this task, continue others"
+      description: "Mark in_progress, keep the plan moving elsewhere"
+    - label: "Log and continue"
+      description: "Record failure, proceed — use only for informational gates"
+```
+
+Store as `failurePolicy`: `"stop-plan"` | `"reopen-continue"` | `"log-continue"`.
+
+### Q5 (conditional) — Subagent dispatch contract
+
+Only when Q2 = "Subagent with briefing".
+
+```yaml
+AskUserQuestion:
+  question: "Paste the exact prompt / briefing the subagent should receive. This becomes the dispatch contract — the agent cannot substitute a shorter version at runtime."
+  header: "Dispatch brief"
+  options:
+    - label: "I'll paste it"
+      description: "Provide the briefing text"
+    - label: "Use instances/<tag>/seed-briefing.md"
+      description: "Per-target briefing file already written by a plan task"
+    - label: "Generate from task description"
+      description: "Build the briefing from the task's Goal + Files + Acceptance Criteria"
+```
+
+Store as `subagentBrief` (string or file-path).
+
+## Writing back
+
+After all questions answered:
+
+1. **Update the task description.** Rewrite the `json:metadata` fence with the new fields. Remove `requiresUserSpecification`. Keep everything else. Call `TaskUpdate` with the full new description.
+
+```json:metadata
+{
+  "files": [...],
+  "verifyCommand": "<from Q2 — the CLI/API string, or '(subagent)' sentinel>",
+  "acceptanceCriteria": ["<from Q1>", ...],
+  "userGate": true,
+  "tags": ["user-gate"],
+  "gateScope": "<from Q3>",
+  "failurePolicy": "<from Q4>",
+  "subagentBrief": "<from Q5 if applicable>"
+}
+```
+
+2. **Append a "Specification" section** to the human-readable part of the task description, above the `json:metadata` fence:
+
+```markdown
+### Specification (via /specify-gate on <ISO-date>)
+
+- **Outcome:** <Q1>
+- **Mechanism:** <Q2>
+- **Scope:** <Q3>
+- **Failure policy:** <Q4>
+- **Subagent brief:** <Q5 if applicable>
+```
+
+3. **Sync `.tasks.json`.** Update the task entry's description and metadata, set `lastUpdated`.
+
+4. **Announce:** "Specification locked. Returning control to executing-plans to run the gate."
+
+## Handoff
+
+Control returns to `executing-plans`. The agent reads the updated task, executes `verifyCommand` (or dispatches the subagent with `subagentBrief`), captures output, and posts `AC: <criterion> — PROVEN BY <evidence>` per criterion before closing.
+
+## What NOT to do in this skill
+
+- Do NOT invoke `ExitPlanMode` or `EnterPlanMode`.
+- Do NOT start the verification. The verification runs back in `executing-plans` after this skill exits.
+- Do NOT ask more than 4-5 questions. If the user's answers feel insufficient, prefer reopening with one follow-up over piling additional questions into the initial flow.
+- Do NOT write to disk anything other than the task description and `.tasks.json`. No side files.
+
+## Integration
+
+- **Invoked from:** `executing-plans` (automatic), `/specify-gate` slash command (manual).
+- **Returns to:** `executing-plans`.
+- **References:** `skills/shared/task-format-reference.md` for metadata schema.

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -283,7 +283,7 @@ This ensures cross-session resume works correctly. Without this, a new session l
 ## Integration
 
 **Required workflow skills:**
-- **superpowers-extended-cc:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
+- **superpowers-extended-cc:using-git-worktrees** - REQUIRED: Set up a session-level isolated workspace before starting. Do NOT pass `isolation: "worktree"` on subagent Agent dispatches — it creates per-subagent worktrees that become orphans on cleanup failure. Pass the session worktree's CWD explicitly in Agent prompts instead.
 - **superpowers-extended-cc:writing-plans** - Creates the plan this skill executes
 - **superpowers-extended-cc:requesting-code-review** - Code review template for reviewer subagents
 - **superpowers-extended-cc:finishing-a-development-branch** - Complete development after all tasks

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,218 +1,160 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - wraps Claude Code native worktree tools with project setup, baseline test verification, and symlink-aware gitignore-safety
 ---
 
 # Using Git Worktrees
 
 ## Overview
 
-Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching.
+Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching. Claude Code provides native tools (`EnterWorktree`, `ExitWorktree`, `claude --worktree`) that handle worktree lifecycle end-to-end. This skill wraps those tools with three things the native flow does not provide: project-setup auto-detection, a baseline test verification step, and a gitignore-safety check tailored to the `.claude/worktrees/` location (including the symlink case).
 
-**Core principle:** Systematic directory selection + safety verification = reliable isolation.
+**Core principle:** Use the native worktree tools for creation and cleanup. Add project setup, baseline verification, and gitignore-safety on top. Never run `git worktree add` manually.
 
 **Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
 
-## Directory Selection Process
+## Creating a Worktree
 
-Follow this priority order:
+### Mid-session
 
-### 1. Check Existing Directories
+Call the `EnterWorktree` tool. It creates a worktree at `.claude/worktrees/<name>/` on branch `worktree-<name>`, then switches the session CWD into it.
 
-```bash
-# Check in priority order
-ls -d .worktrees 2>/dev/null     # Preferred (hidden)
-ls -d worktrees 2>/dev/null      # Alternative
-```
+- Pass a `name` parameter for a descriptive directory and branch name (e.g., `name: "auth-refactor"`).
+- Omit `name` to auto-generate a random one.
+- `EnterWorktree` automatically copies files listed in `.worktreeinclude` (at project root) into the new worktree — use this for gitignored config files the worktree needs to run (e.g., `.env`, `.env.local`).
 
-**If found:** Use that directory. If both exist, `.worktrees` wins.
+### New session
 
-### 2. Check CLAUDE.md
+Launch with `claude --worktree <name>` from the repo root. Claude Code creates the worktree before the session starts and opens the session inside it.
 
-```bash
-grep -i "worktree.*director" CLAUDE.md 2>/dev/null
-```
+### FORBIDDEN
 
-**If preference specified:** Use it without asking.
+- Do **NOT** call `git worktree add` manually. It bypasses `.worktreeinclude` processing, session CWD management, and cleanup integration.
+- Do **NOT** pass `isolation: "worktree"` on `Agent` tool calls to isolate subagents. Each subagent gets its own worktree; if the subagent makes any changes, Claude Code keeps the worktree on session exit, which requires manual `git worktree unlock` + `git worktree remove --force` cleanup. Use a single session-level worktree (this skill) and pass its CWD explicitly in Agent prompts instead.
 
-### 3. Ask User
+## Gitignore-Safety Check (run BEFORE `EnterWorktree`)
 
-If no directory exists and no CLAUDE.md preference:
+The worktree's working tree physically lands at `.claude/worktrees/<name>/` inside the project. If the parent repo does not ignore that path, the worktree's files will appear as untracked in `git status` and risk accidental commits.
 
-```
-No worktree directory found. Where should I create worktrees?
-
-1. .worktrees/ (project-local, hidden)
-2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
-
-Which would you prefer?
-```
-
-## Safety Verification
-
-### For Project-Local Directories (.worktrees or worktrees)
-
-**MUST verify directory is ignored before creating worktree:**
+Check coverage from the repo root:
 
 ```bash
-# Check if directory is ignored (respects local, global, and system gitignore)
-git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
+cd "$(git rev-parse --show-toplevel)"
+git check-ignore -v .claude/worktrees/ 2>&1
 ```
 
-**If NOT ignored:**
+**Three outcomes:**
 
-Per Jesse's rule "Fix broken things immediately":
-1. Add appropriate line to .gitignore
-2. Commit the change
-3. Proceed with worktree creation
+1. **Ignored** (output like `.gitignore:N:pattern  .claude/worktrees/`) — safe, proceed to `EnterWorktree`.
 
-**Why critical:** Prevents accidentally committing worktree contents to repository.
+2. **Not ignored** (empty output, exit code 1) — add it before creating the worktree:
+   ```bash
+   printf '\n# Claude Code native worktrees\n.claude/worktrees/\n' >> .gitignore
+   git add .gitignore
+   git commit -m "chore: ignore .claude/worktrees/"
+   ```
+   Then proceed.
 
-### For Global Directory (~/.config/superpowers/worktrees)
+3. **Symlink case** (error such as `fatal: pathspec '.claude/worktrees/' is beyond a symbolic link` or `fatal: pathspec '.claude/worktrees/' did not match any file(s)`, or `.claude` shows up as a symlink in `ls -la`) — `git check-ignore` cannot traverse symlinks. The native worktree lands in the symlink's target directory, which likely does NOT ignore that path. Warn the user explicitly:
+   > ".claude/ is a symlink. Native worktrees will physically land at `<symlink-target>/worktrees/` and MAY appear as untracked files in the parent-of-symlink repo's `git status`. Verify with `git -C <symlink-target-root> status` before proceeding; add the appropriate gitignore entry at that repo's root if needed."
 
-No .gitignore verification needed - outside project entirely.
+## Post-Creation Project Setup
 
-## Creation Steps
-
-### 1. Detect Project Name
-
-```bash
-project=$(basename "$(git rev-parse --show-toplevel)")
-```
-
-### 2. Create Worktree
+After `EnterWorktree` succeeds and your CWD is inside the worktree, auto-detect and run the project's dependency install:
 
 ```bash
-# Determine full path
-case $LOCATION in
-  .worktrees|worktrees)
-    path="$LOCATION/$BRANCH_NAME"
-    ;;
-  ~/.config/superpowers/worktrees/*)
-    path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
-    ;;
-esac
-
-# Create worktree with new branch
-git worktree add "$path" -b "$BRANCH_NAME"
-cd "$path"
-```
-
-### 3. Run Project Setup
-
-Auto-detect and run appropriate setup:
-
-```bash
-# Node.js
-if [ -f package.json ]; then npm install; fi
+# Node.js / Bun
+if [ -f bun.lockb ] || [ -f bunfig.toml ]; then bun install
+elif [ -f package.json ]; then npm install; fi
 
 # Rust
 if [ -f Cargo.toml ]; then cargo build; fi
 
 # Python
-if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-if [ -f pyproject.toml ]; then poetry install; fi
+if [ -f uv.lock ] || [ -f pyproject.toml ]; then uv sync
+elif [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 # Go
 if [ -f go.mod ]; then go mod download; fi
 ```
 
-### 4. Verify Clean Baseline
+Skip if no recognized project files are present.
 
-Run tests to ensure worktree starts clean:
+## Baseline Test Verification
+
+Run the project's test suite to confirm the worktree starts clean:
 
 ```bash
-# Examples - use project-appropriate command
-npm test
-cargo test
-pytest
-go test ./...
+# Use the project's native test command
+bun test        # Bun
+npm test        # Node
+cargo test      # Rust
+pytest          # Python
+go test ./...   # Go
 ```
 
-**If tests fail:** Report failures, ask whether to proceed or investigate.
+- **Tests pass:** Report ready with count (e.g., "47 tests passing"). Proceed.
+- **Tests fail:** Report failures verbatim. Ask the user whether to proceed with a broken baseline or pause to investigate.
 
-**If tests pass:** Report ready.
+## Exiting a Worktree
 
-### 5. Report Location
+Call `ExitWorktree` when the work is done:
 
-```
-Worktree ready at <full-path>
-Tests passing (<N> tests, 0 failures)
-Ready to implement <feature-name>
-```
+- `action: "keep"` — preserves worktree and branch on disk for later (use when handing off to another session or keeping work uncommitted).
+- `action: "remove"` — deletes worktree and branch. Refuses if uncommitted changes exist, unless `discard_changes: true` is also passed.
+
+If the session ends while still inside a worktree, Claude Code prompts the user to keep or remove it.
 
 ## Quick Reference
 
 | Situation | Action |
 |-----------|--------|
-| `.worktrees/` exists | Use it (verify ignored) |
-| `worktrees/` exists | Use it (verify ignored) |
-| Both exist | Use `.worktrees/` |
-| Neither exists | Check CLAUDE.md → Ask user |
-| Directory not ignored | Add to .gitignore + commit |
-| Tests fail during baseline | Report failures + ask |
-| No package.json/Cargo.toml | Skip dependency install |
+| Mid-session — need isolated workspace | Call `EnterWorktree` with a descriptive `name` |
+| New session — need isolated workspace | Launch `claude --worktree <name>` |
+| `.claude/worktrees/` not gitignored | Add + commit it, then `EnterWorktree` |
+| `.claude/` is a symlink | Warn user about parent-repo exposure; verify with `git -C <target> status` |
+| Need env files in worktree | Create `.worktreeinclude` at project root listing them |
+| Done with worktree — keep work | `ExitWorktree` `action: "keep"` |
+| Done with worktree — discard | `ExitWorktree` `action: "remove"` (add `discard_changes: true` if uncommitted) |
+| Tests fail during baseline | Report verbatim; ask user whether to proceed |
+| No package.json / Cargo.toml / etc. | Skip dependency install |
+| Subagent needs isolation | NO per-subagent `isolation:"worktree"` — pass session worktree CWD explicitly |
 
 ## Common Mistakes
 
-### Skipping ignore verification
+### Calling `git worktree add` manually
 
-- **Problem:** Worktree contents get tracked, pollute git status
-- **Fix:** Always use `git check-ignore` before creating project-local worktree
+- **Problem:** Bypasses native lifecycle management, `.worktreeinclude` handling, and session CWD tracking.
+- **Fix:** Always `EnterWorktree` (mid-session) or `claude --worktree` (new session).
 
-### Assuming directory location
+### Using `isolation: "worktree"` on `Agent`
 
-- **Problem:** Creates inconsistency, violates project conventions
-- **Fix:** Follow priority: existing > CLAUDE.md > ask
+- **Problem:** Each subagent gets its own worktree. If the subagent makes any file changes, Claude Code keeps it on exit, requiring manual `git worktree unlock` + `git worktree remove --force` cleanup per subagent. This multiplies with parallel subagents.
+- **Fix:** Create one session-level worktree with this skill; pass the worktree CWD explicitly in every `Agent` prompt.
 
-### Proceeding with failing tests
+### Skipping the gitignore-safety check
 
-- **Problem:** Can't distinguish new bugs from pre-existing issues
-- **Fix:** Report failures, get explicit permission to proceed
+- **Problem:** If `.claude/worktrees/` is not ignored, the worktree's working tree gets tracked in the parent repo (pollutes `git status`, risks accidental commits). The symlink case is especially silent.
+- **Fix:** Always run the three-outcome check before `EnterWorktree`.
 
-### Hardcoding setup commands
+### Skipping baseline test verification
 
-- **Problem:** Breaks on projects using different tools
-- **Fix:** Auto-detect from project files (package.json, etc.)
-
-## Example Workflow
-
-```
-You: I'm using the using-git-worktrees skill to set up an isolated workspace.
-
-[Check .worktrees/ - exists]
-[Verify ignored - git check-ignore confirms .worktrees/ is ignored]
-[Create worktree: git worktree add .worktrees/auth -b feature/auth]
-[Run npm install]
-[Run npm test - 47 passing]
-
-Worktree ready at /Users/jesse/myproject/.worktrees/auth
-Tests passing (47 tests, 0 failures)
-Ready to implement auth feature
-```
-
-## Red Flags
-
-**Never:**
-- Create worktree without verifying it's ignored (project-local)
-- Skip baseline test verification
-- Proceed with failing tests without asking
-- Assume directory location when ambiguous
-- Skip CLAUDE.md check
-
-**Always:**
-- Follow directory priority: existing > CLAUDE.md > ask
-- Verify directory is ignored for project-local
-- Auto-detect and run project setup
-- Verify clean test baseline
+- **Problem:** Can't distinguish new bugs from pre-existing failures when the work continues.
+- **Fix:** Always run the test suite after setup; report results before proceeding.
 
 ## Integration
 
 **Called by:**
-- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
-- **subagent-driven-development** - REQUIRED before executing any tasks
-- **executing-plans** - REQUIRED before executing any tasks
-- Any skill needing isolated workspace
+- **brainstorming** (Phase 4) — REQUIRED when design is approved and implementation follows
+- **subagent-driven-development** — REQUIRED before executing any tasks (one session-level worktree, NOT per-subagent isolation)
+- **executing-plans** — REQUIRED before executing any tasks
+- Any skill needing an isolated workspace
 
 **Pairs with:**
-- **finishing-a-development-branch** - REQUIRED for cleanup after work complete
+- **finishing-a-development-branch** — REQUIRED for merge/keep/discard decisions after work is complete (delegates cleanup to `ExitWorktree`)
+
+**Native tools wrapped:**
+- `EnterWorktree` — create and enter worktree mid-session
+- `ExitWorktree` — leave with keep/remove decision
+- `claude --worktree <name>` — CLI entry point for new-session worktrees
+- `.worktreeinclude` — project-root file listing gitignored files to copy into new worktrees

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -84,8 +84,8 @@ BRANCH=$(git branch --show-current)
 - `GIT_DIR != GIT_COMMON` → already in a linked worktree (skip creation)
 - `BRANCH` empty → detached HEAD (cannot branch/push/PR from sandbox)
 
-See `using-git-worktrees` Step 0 and `finishing-a-development-branch`
-Step 1 for how each skill uses these signals.
+See `using-git-worktrees` (gitignore-safety check and `EnterWorktree` usage) and
+`finishing-a-development-branch` Step 1 for how each skill uses these signals.
 
 ## Codex App Finishing
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -207,6 +207,42 @@ Use Claude Code's native task tools (v2.1.16+) to create structured tasks alongs
 
 For each task in the plan, create a corresponding native task. Embed metadata as a `json:metadata` code fence at the end of the description — this is the only way to ensure metadata survives TaskGet (the `metadata` parameter on TaskCreate is accepted but not returned by TaskGet).
 
+#### User-Thrown Gates — Mechanical Detection + Tagging
+
+You MUST run this check for EVERY task you create. It takes seconds and is the cheapest part of the whole user-gate flow.
+
+**Step 1 — Scan for gate-language.** For each of these, search the user's brief AND the task's Goal/Acceptance Criteria, case-insensitive, whole-word where reasonable:
+
+| Bucket | Keywords / patterns |
+|--------|---------------------|
+| Verbs | `verify`, `prove`, `validate`, `confirm`, `ensure`, `check`, `gate` |
+| Nouns | `verification gate`, `acceptance test`, `smoke test`, `end-to-end`, `E2E` |
+| Scope | `first on one`, `then all`, `one before the rest`, `before proceeding`, `don't continue until` |
+| Proof | `prove it works`, `make sure`, `demonstrate`, `show that` |
+
+If ANY bucket matches → this task is a user-thrown gate. Continue to Step 2. If nothing matches → regular task, no tagging needed.
+
+**Step 2 — Tag the task.** In the task's `json:metadata` fence:
+
+1. Set `"userGate": true`.
+2. Append `"user-gate"` to the `tags` array (create the array if absent).
+3. If the user's brief specified the HOW concretely (named a command, entity, subagent, or observable), put it straight into `verifyCommand` and `acceptanceCriteria` — done.
+4. If HOW is vague, set `"requiresUserSpecification": true` **only** when the verification sentence names no testable noun (function, command, entity, endpoint, file, log pattern) AND no concrete value (expected result, threshold, example input/output). One foothold — e.g. "verify each op with real inputs" — is enough for the agent to self-solve. The flag is for pure adjectives ("solid", "works", "good", "proper") where any guess is a shot in the dark.
+
+**Step 3 — Add the prose banner** (mandatory whenever `userGate: true`). Near the top of the task description, right under **Goal:**, include verbatim:
+
+> **USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user in the current conversation. It MUST NOT be closed by walking around it, by declaring it "verified inline", or by substituting a cheaper check. Close only after every item in `acceptanceCriteria` has been re-validated independently, with output captured.
+
+**Step 4 — Check acceptance criteria operational specificity.** Each criterion MUST name an observable. Vague ("integration works", "it passes") is not acceptable — rewrite to "sensor X reports idle", "HTTP 200 from `/health`", "setup.done file present", etc. If you cannot make a criterion operational, set `requiresUserSpecification: true` and let `/specify-gate` collect the real answer.
+
+**Step 5 — Per-task isolation self-check.** For every task where you set `userGate: true` and DIDN'T set `requiresUserSpecification: true`, re-read ONLY that task's **Goal** sentence in isolation — pretend no other task exists. Does that sentence alone name an observable, a capture method, AND a pass/fail value? If no to any of the three, set `requiresUserSpecification: true` even if you already filled in a `verifyCommand` from context. Borrowing concreteness from sibling tasks is the failure mode this catches. Example: a plan with per-op tasks saying "verify add(3,2)==5" (concrete) and a final task saying "make sure the whole thing works" (vague) — the per-op tasks anchor; the final task fails this check and MUST carry `requiresUserSpecification: true`.
+
+**Tag liberally.** The three shades of gate (strict user gate / strict agent gate / gray in-between) all get the same tag. Over-tagging is harmless — extra metadata. Under-tagging hides the task from the safety net.
+
+**Do NOT ask the user questions during write-plan.** The opinionated default is "tag it and move on". Users who wanted questions said "brainstorm". If the user's brief is vague about a gate's HOW, the flag `requiresUserSpecification: true` routes the question to execute time where `/specify-gate` handles it in 3-5 short multiple-choice prompts.
+
+See `skills/shared/task-format-reference.md` → "User-Thrown Gates" for the full metadata schema with all six gate-related keys (`userGate`, `tags`, `requiresUserSpecification`, `gateScope`, `failurePolicy`, `subagentBrief`), and `docs/user-gate-flow.md` for the end-to-end flow.
+
 ```yaml
 TaskCreate:
   subject: "Task N: [Component Name]"

--- a/tests/claude-code/test-user-gate-hooks.sh
+++ b/tests/claude-code/test-user-gate-hooks.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Test: User-gate hooks end-to-end on synthetic transcripts.
+# Deterministic, no LLM. Mirrors the zoo example from docs/user-gate-flow.md.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+POST_HOOK="$REPO_ROOT/hooks/examples/post-task-complete-revalidate.sh"
+STOP_HOOK="$REPO_ROOT/hooks/examples/stop-revalidate-user-gates.sh"
+WORK=$(mktemp -d)
+FAILED=0
+# shellcheck disable=SC2064
+trap "rm -rf '$WORK'" EXIT
+
+echo "=== Test: User-Gate Hooks (post-complete + stop) ==="
+echo ""
+
+# Build a canonical transcript that mirrors docs/user-gate-flow.md's zoo example:
+#   Task 1 = user-gate task (userGate:true, tags:[user-gate])
+#   Task 2 = regular task (no gate markers)
+#   Task 1 is closed with status=completed
+#   Assistant then claims "Both gates passed" WITHOUT posting AC:…PROVEN BY evidence
+cat > "$WORK/zoo-no-proof.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Gate 1: E2E on one instance","description":"**Goal:** Prove the full pipeline works on ONE instance.\n\n**USER-ORDERED GATE — NON-SKIPPABLE.** This task was requested by the user.\n\n```json:metadata\n{\"files\":[],\"verifyCommand\":\"./zoo.sh status v0.1.15\",\"acceptanceCriteria\":[\"Fresh instance spun up\",\"Sonnet subagent dispatched\",\"JIT captured\"],\"userGate\":true,\"tags\":[\"user-gate\"]}\n```"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Task 5: Manager scraper","description":"**Goal:** Parse JIT events.\n\n```json:metadata\n{\"files\":[\"mgr/scraper.py\"],\"verifyCommand\":\"pytest tests/\",\"acceptanceCriteria\":[\"10/10 tests pass\"]}\n```"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Both gates passed. Plan 0-7 + Gate 1 + Gate 2 all complete."}]}}
+EOF
+
+# Same transcript, but WITH proof posted after the close.
+cat > "$WORK/zoo-with-proof.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Gate 1","description":"**USER-ORDERED GATE — NON-SKIPPABLE.**\n\n```json:metadata\n{\"userGate\":true,\"tags\":[\"user-gate\"],\"acceptanceCriteria\":[\"c1\",\"c2\"]}\n```"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Gate 1 done.\nAC: c1 — PROVEN BY sensor.foo=idle\nAC: c2 — PROVEN BY notification_message diff\n\nBoth gates passed."}]}}
+EOF
+
+# Transcript with only the prose banner — no json:metadata fence.
+cat > "$WORK/zoo-prose-only.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Gate X","description":"**Goal:** verify.\n\n**USER-ORDERED GATE — NON-SKIPPABLE.** The user requested this."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+
+run_post_hook() {
+    local tid="$1" path="$2"
+    printf '{"tool_name":"TaskUpdate","tool_input":{"taskId":"%s","status":"completed"},"transcript_path":"%s"}' \
+        "$tid" "$path" | bash "$POST_HOOK" 2>"$WORK/stderr"
+    echo "$?"
+}
+
+run_stop_hook() {
+    local path="$1"
+    printf '{"transcript_path":"%s"}' "$path" | bash "$STOP_HOOK" 2>"$WORK/stderr"
+    echo "$?"
+}
+
+assert() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label — expected exit=$expected, got exit=$actual"
+        echo "         stderr: $(head -2 "$WORK/stderr" | tr '\n' ' ')"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+assert_stderr_contains() {
+    local label="$1" needle="$2"
+    if grep -qF "$needle" "$WORK/stderr"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label — stderr missing: $needle"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+echo "Test 1: post-complete hook BLOCKS on gate close without proof"
+rc=$(run_post_hook 1 "$WORK/zoo-no-proof.jsonl")
+assert "exit code" "2" "$rc"
+assert_stderr_contains "stderr mentions /gate-check as recovery path" "/gate-check 1"
+assert_stderr_contains "stderr lists acceptance criteria" "Fresh instance spun up"
+echo ""
+
+echo "Test 2: post-complete hook PASSES on regular task close"
+rc=$(run_post_hook 2 "$WORK/zoo-no-proof.jsonl")
+assert "exit code" "0" "$rc"
+echo ""
+
+echo "Test 3: post-complete hook BLOCKS on prose-only gate banner"
+rc=$(run_post_hook 1 "$WORK/zoo-prose-only.jsonl")
+assert "exit code" "2" "$rc"
+echo ""
+
+echo "Test 4: post-complete hook respects SUPERPOWERS_USERGATE_GUARD=0"
+printf '{"tool_name":"TaskUpdate","tool_input":{"taskId":"1","status":"completed"},"transcript_path":"%s"}' \
+    "$WORK/zoo-no-proof.jsonl" \
+    | SUPERPOWERS_USERGATE_GUARD=0 bash "$POST_HOOK" 2>"$WORK/stderr"
+rc=$?
+assert "exit code" "0" "$rc"
+echo ""
+
+echo "Test 5: stop hook BLOCKS on completion keyword + unproven gate"
+rc=$(run_stop_hook "$WORK/zoo-no-proof.jsonl")
+assert "exit code" "2" "$rc"
+assert_stderr_contains "stderr names the unproven gate" "Gate 1: E2E on one instance"
+assert_stderr_contains "stderr mentions /gate-check" "/gate-check"
+echo ""
+
+echo "Test 6: stop hook PASSES when proof is posted"
+rc=$(run_stop_hook "$WORK/zoo-with-proof.jsonl")
+assert "exit code" "0" "$rc"
+echo ""
+
+echo "Test 7: stop hook PASSES with no completion keyword"
+cat > "$WORK/zoo-working.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Gate 1","description":"**USER-ORDERED GATE**\n\n```json:metadata\n{\"userGate\":true,\"tags\":[\"user-gate\"],\"acceptanceCriteria\":[]}\n```"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Continuing with Task 2."}]}}
+EOF
+rc=$(run_stop_hook "$WORK/zoo-working.jsonl")
+assert "exit code" "0" "$rc"
+echo ""
+
+echo "Test 8: stop hook respects SUPERPOWERS_USERGATE_STOP_GUARD=0"
+printf '{"transcript_path":"%s"}' "$WORK/zoo-no-proof.jsonl" \
+    | SUPERPOWERS_USERGATE_STOP_GUARD=0 bash "$STOP_HOOK" 2>"$WORK/stderr"
+rc=$?
+assert "exit code" "0" "$rc"
+echo ""
+
+echo "Test 9: post-complete hook is idempotent after evidence is posted"
+# Scenario: first close fires the block → agent reopens → posts AC: evidence
+# → closes again. Second close must NOT re-fire.
+cat > "$WORK/zoo-reclose.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Gate","description":"**USER-ORDERED GATE**\n\n```json:metadata\n{\"userGate\":true,\"tags\":[\"user-gate\"],\"acceptanceCriteria\":[\"c1\"]}\n```"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Gate: verify\nAC: c1 — PROVEN BY unittest OK"},{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/zoo-reclose.jsonl")
+assert "post-hook exit 0 when evidence already on record" "0" "$rc"
+echo ""
+
+echo "Test 10: doc + skill files referenced by hooks exist"
+for f in docs/user-gate-flow.md \
+         skills/checking-gates/SKILL.md \
+         skills/specifying-gates/SKILL.md \
+         commands/gate-check.md \
+         commands/specify-gate.md \
+         skills/shared/task-format-reference.md; do
+    if [ -f "$REPO_ROOT/$f" ]; then
+        echo "  [PASS] $f exists"
+    else
+        echo "  [FAIL] $f missing"
+        FAILED=$((FAILED + 1))
+    fi
+done
+echo ""
+
+echo "=== Summary: $FAILED failure(s) ==="
+exit "$FAILED"


### PR DESCRIPTION
## Summary

Rewrites `skills/using-git-worktrees/SKILL.md` to wrap Claude Code native worktree tooling (`EnterWorktree`, `ExitWorktree`, `claude --worktree`) instead of managing `git worktree add` by hand. Addresses #12.

## What changed

| File | Change |
|---|---|
| `skills/using-git-worktrees/SKILL.md` | Full rewrite: native-tool wrapping; symlink-aware gitignore-safety check; obsolete sandbox `index.lock` paragraph removed; project-setup auto-detection and baseline test verification retained |
| `skills/subagent-driven-development/SKILL.md:286` | Integration bullet updated: warn against per-subagent `isolation: "worktree"` on Agent dispatches (creates orphan worktrees) |
| `skills/using-superpowers/references/codex-tools.md:87` | Stale `Step 0` cross-reference replaced with behavior description |
| `skills/finishing-a-development-branch/SKILL.md:200` | Cross-reference notes cleanup delegates to native `ExitWorktree` |
| `README.md:93` | Line 93 updated to mention `EnterWorktree` |

## Why this shape (highlights from #12 investigation)

- **Sandbox `index.lock` paragraph removed:** Commits inside native worktrees succeed on current Claude Code with no `Operation not permitted` error. The paragraph was obsolete.
- **Gitignore-safety retained, not dropped:** `.worktreeinclude` and gitignore-safety solve different problems. `.worktreeinclude` copies source files INTO a new worktree; gitignore-safety prevents the worktree's own filesystem location from being tracked by the parent repo. Both are needed.
- **Symlink case surfaced:** When `.claude/` is a symlink, native worktrees land in the symlink target, which the parent repo typically does NOT ignore. The rewritten skill documents both observed `git check-ignore` error shapes and instructs an explicit user warning for this case.
- **Hybrid subagent integration:** Per-subagent `isolation: "worktree"` on Agent dispatches leaves orphan worktrees when subagents exit with changes. The skill now recommends one session-level worktree and passing CWD explicitly to Agent calls.

## Test plan

- [x] `EnterWorktree` + `git commit` inside a native worktree — succeeds without sandbox errors
- [x] `git check-ignore -v .claude/worktrees/` on a repo with `.claude/` as a symlink — triggers the Outcome 3 "symlink case" branch (error: `is beyond a symbolic link`)
- [x] `grep -rn 'git worktree add' skills/` — 3 hits, all in prohibition contexts, zero as instructions
- [x] Call-site inventory matches investigation findings (6 files across `skills/` and `README.md`)
- [ ] End-to-end behavior test: fresh subagent invoking the rewritten skill against a throwaway repo where `.claude/worktrees/` is NOT gitignored — should trigger Outcome 2, add to `.gitignore`, commit, then `EnterWorktree` (pending)

## Out of scope

- `skills/subagent-driven-development/implementer-prompt.md` branch-guard to address the wrong-branch-commit pattern reported in the issue thread — distinct concern; addressable in a separate change if the reporter chooses to open an issue for it.

Fixes #12.