### PR TITLE
Fix Codex plugin validation issues

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,13 +7,6 @@
     "email": "jesse@fsck.com",
     "url": "https://github.com/obra"
   },
-  "contributors": [
-    {
-      "name": "pcvelz",
-      "url": "https://github.com/pcvelz",
-      "role": "Fork maintainer"
-    }
-  ],
   "homepage": "https://github.com/pcvelz/superpowers",
   "repository": "https://github.com/pcvelz/superpowers",
   "license": "MIT",

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: shared
+description: Shared reference material consumed by other Superpowers skills; not for direct invocation.
+---
+
+# Shared References
+
+This folder stores shared documents that other Superpowers skills reference.


### PR DESCRIPTION
## Summary
- remove unsupported `contributors` field from `.codex-plugin/plugin.json`
- add `skills/shared/SKILL.md` so the shared skill folder is valid

## Validation
- `python3 /home/bonk/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .` (passes)