### PR TITLE
fix(hooks): broaden assessment-language detection in post-task-complete-revalidate

### DIFF
--- a/hooks/examples/post-task-complete-revalidate.sh
+++ b/hooks/examples/post-task-complete-revalidate.sh
@@ -70,7 +70,7 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 # for this taskId, extract the description, and parse the json:metadata fence.
 # Python (no heredoc — avoids bash 5.3 heredoc-hang regression).
 PY_PARSE='
-import json, re, sys
+import json, os, re, sys
 path = sys.argv[1]
 task_id = str(sys.argv[2])
 
@@ -225,9 +225,31 @@ for (i, txt) in user_text_indices:
 # in the window — subagent reports arrive as tool_result entries, and a close
 # right after a successful subagent return would otherwise look silent.
 assess_re = re.compile(
-    r"\b(verified|confirmed|tested|checked|passed|success|succeeded|result|output|works?|working|acceptance|criterion|criteria|proven|observed|shows?|displayed|returned|exit\s*0|all\s+green|done|complete|built|created|written|wrote)\b",
+    r"\b(verified|confirmed|tested|checked|passed|success|succeeded|result|output|works?|working"
+    r"|acceptance|criterion|criteria|proven|observed|shows?|displayed|returned|exit\s*0|all\s+green"
+    r"|done|complete|built|created|written|wrote"
+    # Issue #19: legitimate assessment vocabulary the original list omitted.
+    # Multi-character / low-ambiguity tokens only — bare singles like
+    # read|run|ran|noted|applied|called are deliberately excluded because
+    # they appear in non-assessment narration ("I will read the file",
+    # "run it later", "as noted above") and would let silent closes pass.
+    r"|assess(ed|ment)?|closed|closure|executed|answered|repl(y|ied)|responded"
+    r"|captured|recorded|logged|dispatched|spawned|invoked|inspected|parsed|scanned"
+    r"|measured|examined|reviewed|audited|summary|summari[sz]ed|finished|finali[sz]ed"
+    r"|legitimate|merged|committed|pushed|patched|implemented|validated)\b",
     re.IGNORECASE,
 )
+
+# Issue #19: optional user-extensible vocabulary, mirroring the
+# SUPERPOWERS_USERGATE_GUARD env convention. Comma-separated literal tokens.
+_extra_kw = os.environ.get("SUPERPOWERS_USERGATE_KEYWORDS", "").strip()
+if _extra_kw:
+    _terms = [re.escape(t.strip()) for t in _extra_kw.split(",") if t.strip()]
+    if _terms:
+        assess_re = re.compile(
+            assess_re.pattern[:-3] + "|" + "|".join(_terms) + r")\b",
+            re.IGNORECASE,
+        )
 
 in_window_texts = [t for (i, t) in text_indices if i >= scan_from]
 in_window_results = [t for (i, t) in tool_result_indices if i >= scan_from]
@@ -247,6 +269,12 @@ if not out["agent_last_assessment"]:
         if assess_re.search(rtxt):
             out["agent_last_assessment"] = True
             break
+
+# Note (issue #19): a digit+word-count fallback ("structured narration counts
+# as assessment") was prototyped here and removed after adversarial testing —
+# deferral closes with incidental digits ("task 1 of 5 out of the way, moving
+# on") passed it, inverting the purpose of this hook. Keyword vocabulary plus the
+# SUPERPOWERS_USERGATE_KEYWORDS extension carry the false-positive fix instead.
 
 # Axis-based evidence enforcement: the plan declares WHAT axes must appear in
 # the close evidence. Each axis = a list of alternative tokens; at least one

--- a/tests/claude-code/test-user-gate-hooks.sh
+++ b/tests/claude-code/test-user-gate-hooks.sh
@@ -493,6 +493,71 @@ else
 fi
 echo ""
 
+echo "Test W: issue #19 — narrated close with count+vocabulary passes"
+cat > "$WORK/nongate-narrated.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Clarifying questions","description":"**Goal:** gather decisions."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Task #1 closure assessment: 3 AskUserQuestion calls executed; all 6 sub-questions answered (decisions captured in section A-F). Decisions recorded above. Reclosing legitimate."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/nongate-narrated.jsonl")
+assert "issue #19 narrated close (assessment vocab + digit) → pass (exit 0)" "0" "$rc"
+echo ""
+
+echo "Test X: truly-silent prose close still blocks"
+cat > "$WORK/nongate-prose-silent.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Clarifying questions","description":"**Goal:** gather decisions."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Moving on to the next one."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/nongate-prose-silent.jsonl")
+assert "truly-silent prose close still blocks (exit 2)" "2" "$rc"
+echo ""
+
+echo "Test Y: digit-alone short close still blocks"
+cat > "$WORK/nongate-digit-short.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Clarifying questions","description":"**Goal:** gather decisions."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"On to 2."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/nongate-digit-short.jsonl")
+assert "digit-alone short close still blocks (exit 2)" "2" "$rc"
+echo ""
+
+echo "Test Z: SUPERPOWERS_USERGATE_KEYWORDS extension works"
+cat > "$WORK/nongate-custom-kw.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Clarifying questions","description":"**Goal:** gather decisions."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Frobnicated the widget per spec."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/nongate-custom-kw.jsonl")
+assert "custom-kw narration WITHOUT env var → blocks (exit 2)" "2" "$rc"
+rc=$(SUPERPOWERS_USERGATE_KEYWORDS="frobnicated" run_post_hook 1 "$WORK/nongate-custom-kw.jsonl")
+assert "custom-kw narration WITH SUPERPOWERS_USERGATE_KEYWORDS=frobnicated → pass (exit 0)" "0" "$rc"
+echo ""
+
+echo "Test AA: deferral closes with incidental digits still block (issue #19 red-team pin)"
+cat > "$WORK/nongate-deferral.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Clarifying questions","description":"**Goal:** gather decisions."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Okay, that is task 1 of 5 out of the way, going to move straight on to the next item without further ado."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/nongate-deferral.jsonl")
+assert "inertia deferral close (digits, 12+ words, no assessment vocab) → blocks (exit 2)" "2" "$rc"
+cat > "$WORK/nongate-deferral2.jsonl" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskCreate","input":{"subject":"Clarifying questions","description":"**Goal:** gather decisions."}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"in_progress"}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I will leave that to the user to look at later, it is item 4 and quite low priority for now."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}
+EOF
+rc=$(run_post_hook 1 "$WORK/nongate-deferral2.jsonl")
+assert "user-deferral close (digits, 12+ words, no assessment vocab) → blocks (exit 2)" "2" "$rc"
+echo ""
+
 echo "Test 10: doc + skill files referenced by hooks exist"
 for f in docs/user-gate-flow.md \
          skills/checking-gates/SKILL.md \


### PR DESCRIPTION
### Problem

`hooks/examples/post-task-complete-revalidate.sh` decides whether a non-gate task close is "silent" via a fixed keyword regex (`assess_re`). Legitimate closes narrated in non-canonical vocabulary ("closure assessment… executed… answered… captured… recorded… legitimate") match nothing and block with the `TASK CLOSED WITHOUT ASSESSMENT` lecture, while a lazy "All done." passes. Reported in #19 with exact reproduction; independently confirmed (each re-fire also re-injects the stderr lecture into context, costing tokens).

Reproduced empirically on pre-fix code: the issue's narration → exit 2; same text + "done" → exit 0; "All done." → exit 0; "Moving on." → exit 2.

### Fix (two components)

1. **Vocabulary expansion** (`assess_re`): ~30 vetted assessment tokens (assess/assessed/assessment, closure/closed, executed, answered, replied/responded, captured, recorded, logged, dispatched, spawned, invoked, inspected, parsed, scanned, measured, examined, reviewed, audited, summary, summarised/summarized, finished, finalised/finalized, legitimate, merged, committed, pushed, patched, implemented, validated). Ambiguous bare tokens (read/run/ran/noted/applied/called) deliberately excluded — they occur in non-assessment narration and would admit silent closes.
2. **`SUPERPOWERS_USERGATE_KEYWORDS` env var**: comma-separated literal tokens, `re.escape`d and appended to the built-in pattern at runtime. Guarded against empty/garbage values; fail-open behavior preserved. Mirrors the `SUPERPOWERS_USERGATE_GUARD` convention.

A third component — the simplest version of the issue's proposal #3, a digit plus ≥12 words counting as assessed — was tried and **removed after adversarial review**: it passed deferral closes ("that is task 1 of 5 out of the way, moving straight on…"), precisely the inertia closes this hook exists to catch. Those cases are pinned as regression tests instead, and the hook carries a comment at the removal site documenting why.

Untouched on purpose: the user-gate path, the A/B evidence-axis logic, and both sibling hooks (verified they do not share `assess_re`). Issue proposal #6 declined as already-satisfied: blocking already requires all three signals (user message, evidence string, assessment language) to be absent — the false positive came from the keyword list being too narrow, not from how the signals combine. The non-blocking variant (#4) is deferred to its own discussion; it changes what the hook enforces. The LLM judge (#5) stays out of default behavior (zero-dependency, deterministic, offline design).

### Tests

`tests/claude-code/test-user-gate-hooks.sh` — full harness green (0 failures), new tests:

- **W**: issue #19's exact narration → pass
- **X**: truly-silent prose close ("Moving on to the next one.") → still blocks
- **Y**: digit-only short close ("On to 2.") → still blocks
- **Z**: `SUPERPOWERS_USERGATE_KEYWORDS=frobnicated` admits an otherwise-blocked close; without the var it blocks
- **AA**: two deferral closes with incidental digits and 12+ words (red-team samples) → still block

Review trail: independent code review (heredoc quoting safety, capture groups, env-injection probes, test conventions) — approved. Adversarial review — env-var splice poisoning held (`re.escape` neutralizes every attempted injection; a hypothetical parse crash fails closed, not open), performance 0.12–0.20s against a 10,003-line transcript, and its two material findings (the digit/word-count check admitted deferral closes and was untested) were resolved by removing that check and pinning its attack samples as tests AA.

### Known separate issue

During live verification a distinct failure mode surfaced: some model/harness combinations persist inter-tool narration as opaque non-plaintext transcript blocks, invisible to any transcript text scan. Tracked separately; it does not affect environments where narration reaches the transcript as text (as in the #19 report, whose hook stderr quoted the narration back).

### Authoring disclosure

Produced in a Claude Code session (model: Fable 5; superpowers-extended-cc plugin active) via orchestrated subagents (reproduction, design analysis, implementation, independent review, adversarial review), with maintainer review of the complete diff and PR text before submission.

Fixes #19