### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,5 @@
-# Ensure shell scripts always have LF line endings
-*.sh text eol=lf
-hooks/session-start text eol=lf
-
-# Ensure the polyglot wrapper keeps LF (it's parsed by both cmd and bash)
-*.cmd text eol=lf
-
-# Common text files
-*.md text eol=lf
-*.json text eol=lf
-*.js text eol=lf
-*.mjs text eol=lf
-*.ts text eol=lf
+# Normalize line endings to LF for all text files
+* text=auto eol=lf
 
 # Explicitly mark binary files
 *.png binary


### PR DESCRIPTION
Replace per-pattern eol=lf rules with a single `* text=auto eol=lf` default.

Cleans up and prevents future stale file states.

this didn't require usage of AI, just a common file pattern.

Be aware that **anybody who has already cloned this repo** will need to `git rm --cached -r . && git reset --hard`, otherwise your local will not pick up this change if you try to submit a PR 

This fixes issue #22 