### PR TITLE
Remove command wrappers that duplicate skills in the slash menu

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,0 @@
----
-description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores requirements and design before implementation."
----
-
-Invoke the superpowers-extended-cc:brainstorming skill and follow it exactly as presented to you

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,5 +1,0 @@
----
-description: Execute plan in batches with review checkpoints
----
-
-Invoke the superpowers-extended-cc:executing-plans skill and follow it exactly as presented to you

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,5 +1,0 @@
----
-description: Create detailed implementation plan with bite-sized tasks
----
-
-Invoke the superpowers-extended-cc:writing-plans skill and follow it exactly as presented to you


### PR DESCRIPTION
> **Note on base branch:** the template asks PRs to target `dev`, but this fork has no `dev` branch (`git ls-remote` shows only `main`), and every previously merged PR here (#2, #4, #21, #23) targeted `main`. Happy to retarget if a `dev` branch is created.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.241, Windows 11 |
| All plugins installed | superpowers-extended-cc 6.4.3-dev, knowledge-capture 0.5.0 |
| Human partner who reviewed this diff | @omarc1492 — the diff is three whole-file deletions (15 lines total); the full contents of all three files were read and reviewed in-session before approval |

## What problem are you trying to solve?

In a real session, typing `/brainstorm` in Claude Code showed **two near-identical autocomplete entries**: the `commands/brainstorm.md` wrapper and the `skills/brainstorming` skill. Their descriptions differ only by the words "user intent", so the user could not tell whether the two entries did different things (they don't — the wrapper's whole body is "Invoke the superpowers-extended-cc:brainstorming skill and follow it exactly as presented to you"). The same duplication exists for `/execute-plan` vs `/executing-plans` and `/write-plan` vs `/writing-plans`.

The wrappers date from when skills weren't user-invocable and needed a command to expose them. Claude Code now lists plugin skills directly in the `/` menu, so these wrappers only add confusing noise. Upstream obra/superpowers has already removed its `commands/` directory for the same reason.

## What does this PR change?

Deletes the three command wrappers that are pure one-line skill forwarders: `commands/brainstorm.md`, `commands/execute-plan.md`, `commands/write-plan.md`. Nothing else — 3 files changed, 0 additions, 15 deletions.

## Is this change appropriate for the core library?

Yes — it removes redundant plugin surface that affects every user of this plugin, regardless of project type. No new skill, no third-party integration, no project-specific config.

## What alternatives did you consider?

1. **Delete all six `commands/` files, matching upstream's full removal.** Rejected after a repo-wide reference audit: `gate-check.md` and `specify-gate.md` pass `$ARGUMENTS` (the task id) to their skills and are the documented interface — the example hooks print `/gate-check <id>` / `/specify-gate <id>` into stderr, README.md and docs/user-gate-flow.md reference them throughout, and `tests/claude-code/test-user-gate-hooks.sh` (Test 10) asserts both files exist. `onboard.md` has no skill equivalent at all — the command is the entire `/onboard` implementation. Deleting those three would have broken the user-gate flow and onboarding.
2. **Do nothing.** Rejected: the duplicate entries actively mislead users into thinking the two entries differ.

## Does this PR contain multiple unrelated changes?

No — three deletions of the same class (pure unreferenced skill-forwarder wrappers), verified individually.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found (reviewed all 11 open+closed PRs; #26 "Onboard upstream 6.1.x changes" is the closest but does not touch `commands/`)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI (Windows 11)        | 2.1.241         | Claude Fable 5 | claude-fable-5 |

## New harness support (required if this PR adds a new harness)

N/A — this PR does not add harness support.

## Evaluation

- Initial prompt: user asked why `/brainstorm` autocompletes to two near-identical entries; investigation traced it to the wrapper/skill duplication.
- Verification performed on this branch vs unmodified `main`:
  - **Repo-wide reference sweep** (all file types: md, json, sh, hooks, tests) for the three deleted names in every form (`/name`, `:name`, `commands/name.md`): zero references to the deleted files remain. The only mentions of the old names are (a) `hooks/pre-askuser-handoff-guard`, which deliberately matches both old command names and current skill names — its old-name branches become dead code but keep working unchanged, and (b) prose using "write-plan" as a phase name in docs, which reads fine.
  - **`tests/claude-code/test-fork-validation.sh`**: all 6 checks pass on this branch (exit 0).
  - **`tests/claude-code/test-user-gate-hooks.sh`**: 36 failures on this branch and **the identical 36 failures on unmodified `main`** (pre-existing, environmental — Unix shell hooks under Windows Git Bash). Test 10 (existence of `commands/gate-check.md`, `commands/specify-gate.md`, and the hook-referenced docs/skills) passes on both.
  - **`tests/claude-code/test-handoff-guard.sh`**: 21 failures on this branch, identical 21 on unmodified `main` — no regression from this change.
  - Manifests checked: `.claude-plugin/plugin.json` and `marketplace.json` do not enumerate command files, so plugin loading is unaffected.
- Behavioral outcome: `/superpowers-extended-cc:brainstorming`, `:executing-plans`, and `:writing-plans` remain invocable from the slash menu; the duplicate entries disappear. No skill content changed.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing — **N/A: no SKILL.md or behavior-shaping content is touched; this PR only deletes three one-line forwarder files**
- [x] This change was tested adversarially, not just on the happy path — the adversarial pass is what shrank the deletion from six files to three (see Alternatives)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement — no such content is touched

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission — the complete diff is the deletion of three files totalling 15 lines; their full contents were displayed to and reviewed by the human partner in-session, who approved the removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
