### PR TITLE
fix(writing-plans): recommend an execution method in the handoff question

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -205,10 +205,12 @@ AskUserQuestion:
   header: "Execution"
   options:
     - label: "Subagent-Driven (this session)"
-      description: "I dispatch fresh subagent per task, review between tasks, fast iteration"
+      description: "Runs here: fresh subagent per task, each result reviewed before the next. Good default."
     - label: "Parallel Session (separate)"
-      description: "Open new session in worktree with executing-plans, batch execution with checkpoints; it can message this session to consult"
+      description: "You open a second session in the worktree that runs the plan while this one stays free; it can consult this session. For long plans or a nearly-full context."
 ```
+
+**Recommend one option:** append " (Recommended)" to the better fit's label (list it first) and prepend a one-line reason to its description. Default Subagent-Driven; pick Parallel Session for large plans (~10+ tasks) or a heavily-used session. Never reword the base labels.
 
 **If you are about to call ExitPlanMode, STOP — call AskUserQuestion instead.**
 


### PR DESCRIPTION
## Summary

Fixes #33 — the execution handoff now recommends the better-fitting option and explains both choices in plain language.

- Reworded the two option descriptions in the `writing-plans` Execution Handoff so a first-time user can tell them apart ("Runs here: fresh subagent per task…" / "You open a second session in the worktree…")
- Added an instruction to assess the plan and append " (Recommended)" to the better fit's label, list it first, and prepend a one-line reason to its description (default Subagent-Driven; Parallel Session for large plans or a heavily-used session)
- Base label text stays verbatim, so the `pre-askuser-handoff-guard` hook (substring match on both labels) passes unchanged

## Root cause

The handoff question presented two options with terse descriptions and no guidance. New users had no basis to choose; free-texting "what do you suggest?" worked, which showed the missing piece was a recommendation at the decision moment.

## Test plan

- [x] Dry-run simulation (small plan, 3 tasks): all 5 compliance checks pass — TaskCreate with modelTier, no ExitPlanMode, both base labels present, Subagent-Driven recommended and listed first, labels unmodified
- [x] Dry-run simulation (large plan, 12 tasks): Parallel Session recommended, options array reordered, exactly one "(Recommended)" suffix
- [ ] Real plan-writing session end-to-end